### PR TITLE
Use custom scorer

### DIFF
--- a/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -34,7 +34,7 @@ object SearchServer extends App {
 
   def managedStartable[T <: { def start() } : Resource](resource: => T): Managed[T] = new Managed[T] {
     override def run[A](f: T => A): A =
-      using(resource) { r =>        import scala.language.reflectiveCalls
+      using(resource) { r =>
         import scala.language.reflectiveCalls
         r.start()
         f(r)

--- a/src/main/scala/com/socrata/cetera/config/AppConfig.scala
+++ b/src/main/scala/com/socrata/cetera/config/AppConfig.scala
@@ -36,4 +36,5 @@ class ElasticSearchConfig(config:Config, root:String) extends ConfigClass(config
   val elasticSearchServer = getString("es-server")
   val elasticSearchPort = getInt("es-port")
   val elasticSearchClusterName = getString("es-cluster-name")
+  val useCustomRanker = optionally(getBoolean("use-custom-ranker")).getOrElse(false)
 }

--- a/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
@@ -1,21 +1,20 @@
 package com.socrata.cetera.search
 
 import java.io.Closeable
+import scala.collection.JavaConverters._
 
 import org.elasticsearch.action.search.{SearchRequestBuilder, SearchResponse}
 import org.elasticsearch.client.Client
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.settings.ImmutableSettings
 import org.elasticsearch.common.transport.InetSocketTransportAddress
-import org.elasticsearch.index.query.{FilterBuilders, QueryBuilders }
-import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders
 import org.elasticsearch.index.query.MultiMatchQueryBuilder
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders
+import org.elasticsearch.index.query.{FilterBuilders, QueryBuilders}
 import org.elasticsearch.search.aggregations.AggregationBuilders
 import org.elasticsearch.search.aggregations.bucket.terms.Terms
 import org.elasticsearch.search.sort.{SortBuilders, SortOrder}
 
-import scala.collection.JavaConverters._
-import com.socrata.cetera.types.CeteraFieldType
 import com.socrata.cetera.types._
 import EnrichedFieldTypesForES._
 
@@ -84,16 +83,16 @@ class ElasticSearchClient(host: String, port: Int, clusterName: String, useCusto
     val finalQuery = client
                        .prepareSearch("datasets", "pages") // literals should not be here
                        .setTypes(only.toList:_*)
-   
+
     if (useCustomRanker) {
       val custom = QueryBuilders.functionScoreQuery(query).boostMode("replace")
-      val script = ScoreFunctionBuilders.scriptFunction("cetera-ranker", 
-                                                        "native", 
-                                                        Map("boostLastUpdatedAtValue"-> 1.5, 
-                                                          "boostPopularityValue" -> 1.0).
-                                                          asInstanceOf[Map[String,Object]].asJava)
+      val script = ScoreFunctionBuilders.scriptFunction(
+        "cetera-ranker",
+        "native",
+        Map("boostLastUpdatedAtValue"-> 1.5,
+            "boostPopularityValue" -> 1.0).asInstanceOf[Map[String,Object]].asJava
+      )
       custom.add(script)
-      println(custom.toString) 
       finalQuery.setQuery(custom)
     }
     else finalQuery.setQuery(query)

--- a/src/main/scala/com/socrata/cetera/search/EnrichedFieldTypesForES.scala
+++ b/src/main/scala/com/socrata/cetera/search/EnrichedFieldTypesForES.scala
@@ -1,6 +1,5 @@
 package com.socrata.cetera.search
 
-import com.socrata.cetera.types.CeteraFieldType
 import com.socrata.cetera.types._
 
 object EnrichedFieldTypesForES {

--- a/src/test/scala/com/socrata/cetera/search/ElasticSearchClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/ElasticSearchClientSpec.scala
@@ -122,7 +122,8 @@ class ElasticSearchClientSpec extends WordSpec with ShouldMatchers {
   val multiMatchQuery = j"""{
     "multi_match" : {
       "query" : ${params.searchQuery.get},
-      "fields" : [ "indexed_metadata.name^2.2", "indexed_metadata.description^1.1", "_all" ]
+      "fields" : [ "indexed_metadata.name^2.2", "indexed_metadata.description^1.1", "_all" ],
+      "type" : "cross_fields"
     }
   }"""
 


### PR DESCRIPTION
Add logic to use custom scorer if defined in config. Note that this ranker is currently not open source.  If the config is not defined, we will use our default ranker.

Additionally, this modifies the ES query to use cross_fields and not best_fields.  Initial smell tests showed that this improved results, but we require more formal verification.