### PR TITLE
Set query analyzer to standard

### DIFF
--- a/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
@@ -44,7 +44,7 @@ class ElasticSearchClient(host: String, port: Int, clusterName: String, useCusto
       case Some(sq) if boosts.isEmpty =>
         QueryBuilders.multiMatchQuery(sq, "_all")
           .`type`(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-          .analyzer("snowball")
+          .analyzer("standard")
 
       case Some(sq) =>
         val text_args = boosts.map {
@@ -55,7 +55,7 @@ class ElasticSearchClient(host: String, port: Int, clusterName: String, useCusto
 
         QueryBuilders.multiMatchQuery(sq, text_args.toList:_*)
           .`type`(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-          .analyzer("snowball")
+          .analyzer("standard")
     }
 
     val query = locally {

--- a/src/test/scala/com/socrata/cetera/search/ElasticSearchClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/ElasticSearchClientSpec.scala
@@ -115,7 +115,7 @@ class ElasticSearchClientSpec extends WordSpec with ShouldMatchers {
       "query" : ${params.searchQuery.get},
       "fields" : ["_all"],
       "type" : "cross_fields",
-      "analyzer" : "snowball"
+      "analyzer" : "standard"
     }
   }"""
 
@@ -124,7 +124,7 @@ class ElasticSearchClientSpec extends WordSpec with ShouldMatchers {
       "query" : ${params.searchQuery.get},
       "fields" : [ "indexed_metadata.name^2.2", "indexed_metadata.description^1.1", "_all" ],
       "type" : "cross_fields",
-      "analyzer" : "snowball"
+      "analyzer" : "standard"
     }
   }"""
 


### PR DESCRIPTION
We should again set the analyzer to snowball once we have updated our
indexes to support the snowball analyzer.