### PR TITLE
Use Lucene Expression instead of Groovy for function score scripts

### DIFF
--- a/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
@@ -53,7 +53,7 @@ class ElasticSearchClient(host: String, port: Int, clusterName: String, useCusto
     def addFunctionScores(query: FunctionScoreQueryBuilder,
                           functions: List[ScriptScoreFunction]) = {
       functions.foreach { fn =>
-        query.add(ScoreFunctionBuilders.scriptFunction(fn.script, fn.params.asJava))
+        query.add(ScoreFunctionBuilders.scriptFunction(fn.script, "expression", fn.params.asJava))
       }
 
       query.scoreMode("sum")


### PR DESCRIPTION
Since the syntax for our base function body is the same whether it's Groovy or Lucene Expression, the only change required here was to specify the lang when instantiating the ScriptFunction.