### PR TITLE
Set default sort order as view count

### DIFF
--- a/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
@@ -169,6 +169,7 @@ class ElasticSearchClient(host: String,
 
   private val sortScoreDesc: SortBuilder = SortBuilders.scoreSort().order(SortOrder.DESC)
   private def sortFieldDesc(field: String): SortBuilder = SortBuilders.fieldSort(field).order(SortOrder.DESC)
+  private val sortCountDesc: SortBuilder = SortBuilders.fieldSort("page_views.page_views_total").order(SortOrder.DESC)
 
   // First pass logic is very simple. advanced query >> query >> categories >> tags
   def buildSearchRequest(searchQuery: QueryType, // scalastyle:ignore parameter.number
@@ -185,7 +186,8 @@ class ElasticSearchClient(host: String,
                          limit: Int,
                          advancedQuery: Option[String] = None ): SearchRequestBuilder = {
     val sort = (searchQuery, categories, tags) match {
-      case (NoQuery, None, None) => sortScoreDesc
+      case (NoQuery, None, None) => sortCountDesc
+
       case (AdvancedQuery(_) | SimpleQuery(_), _, _)  => sortScoreDesc // Query
 
       // Categories
@@ -198,15 +200,17 @@ class ElasticSearchClient(host: String,
 
       // Categories and search context
       // TODO: Should we sort by popularity?
-      case (_, Some(cats), _) if searchContext.isDefined => sortFieldDesc(TitleFieldType.fieldName)
+      case (_, Some(cats), _) if searchContext.isDefined => sortCountDesc
 
       // Tags
-      case (_, _, Some(ts)) =>
+      case (_, _, Some(ts)) if searchContext.isEmpty=>
         SortBuilders
           .fieldSort("animl_annotations.tags.score")
           .order(SortOrder.DESC)
           .sortMode("avg")
           .setNestedFilter(FilterBuilders.termsFilter(TagsFieldType.rawFieldName, ts.toSeq:_*))
+
+      case (_, _, Some(ts)) => sortCountDesc
     }
 
     buildBaseRequest(searchQuery, domains, searchContext, categories, tags,

--- a/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
@@ -1,9 +1,8 @@
 package com.socrata.cetera.search
 
 import java.io.Closeable
+import scala.collection.JavaConverters._
 
-import com.socrata.cetera.search.EnrichedFieldTypesForES._
-import com.socrata.cetera.types._
 import org.elasticsearch.action.search.SearchRequestBuilder
 import org.elasticsearch.client.Client
 import org.elasticsearch.client.transport.TransportClient
@@ -16,7 +15,8 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms
 import org.elasticsearch.search.sort.{SortBuilder, SortBuilders, SortOrder}
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import com.socrata.cetera.search.EnrichedFieldTypesForES._
+import com.socrata.cetera.types._
 
 class ElasticSearchClient(host: String,
                           port: Int,
@@ -169,7 +169,7 @@ class ElasticSearchClient(host: String,
 
   private val sortScoreDesc: SortBuilder = SortBuilders.scoreSort().order(SortOrder.DESC)
   private def sortFieldDesc(field: String): SortBuilder = SortBuilders.fieldSort(field).order(SortOrder.DESC)
-  private val sortCountDesc: SortBuilder = SortBuilders.fieldSort("page_views.page_views_total").order(SortOrder.DESC)
+  private val sortViewsDesc: SortBuilder = SortBuilders.fieldSort("page_views.page_views_total").order(SortOrder.DESC)
 
   // First pass logic is very simple. advanced query >> query >> categories >> tags
   def buildSearchRequest(searchQuery: QueryType, // scalastyle:ignore parameter.number
@@ -186,7 +186,7 @@ class ElasticSearchClient(host: String,
                          limit: Int,
                          advancedQuery: Option[String] = None ): SearchRequestBuilder = {
     val sort = (searchQuery, categories, tags) match {
-      case (NoQuery, None, None) => sortCountDesc
+      case (NoQuery, None, None) => sortViewsDesc
 
       case (AdvancedQuery(_) | SimpleQuery(_), _, _)  => sortScoreDesc // Query
 
@@ -200,17 +200,17 @@ class ElasticSearchClient(host: String,
 
       // Categories and search context
       // TODO: Should we sort by popularity?
-      case (_, Some(cats), _) if searchContext.isDefined => sortCountDesc
+      case (_, Some(cats), _) if searchContext.isDefined => sortViewsDesc
 
       // Tags
-      case (_, _, Some(ts)) if searchContext.isEmpty=>
+      case (_, _, Some(ts)) if searchContext.isEmpty =>
         SortBuilders
           .fieldSort("animl_annotations.tags.score")
           .order(SortOrder.DESC)
           .sortMode("avg")
           .setNestedFilter(FilterBuilders.termsFilter(TagsFieldType.rawFieldName, ts.toSeq:_*))
 
-      case (_, _, Some(ts)) => sortCountDesc
+      case (_, _, Some(ts)) => sortViewsDesc
     }
 
     buildBaseRequest(searchQuery, domains, searchContext, categories, tags,


### PR DESCRIPTION
When no search term is specified, and search context is specified
sort by the page view count as opposed to arbitrary sort ordering

Reviewed-by: jason.kroll@socrata.com