### PR TITLE
Adding default filters for is_customer_domain and moderation_status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Now you are ready to docker.
 ## Endpoints!
 
 We support a few endpoints:
-* `/version` returns the version
 
+* `/version` returns the version
 * `/catalog` returns search results for query passed in parameter `q`
 * `/catalog/domains` returns a count query grouped by domain
 * `/catalog/categories` returns a count query grouped by category

--- a/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -34,6 +34,14 @@ case object DomainFieldType extends Countable with Rawable {
   val fieldName: String = "socrata_id.domain_cname"
 }
 
+case object IsCustomerDomainFieldType extends CeteraFieldType {
+  val fieldName: String = "is_customer_domain"
+}
+
+case object ModerationStatusFieldType extends CeteraFieldType {
+  val fieldName: String = "moderation_status"
+}
+
 case object CategoriesFieldType extends Scorable with Rawable {
   val fieldName: String = "animl_annotations.categories"
   case object Name extends NestedField with Rawable {


### PR DESCRIPTION
#### Purpose

This commit:
  1. Unconditionally applies a filter to only allow views where the `moderation_status` is not  `pending` or `rejected`.  Effectually asking for `accepted` or `irrelevant`, but allowing for `moderation_status` to not exist.  
  2.  Conditionally applies a filter to only allow customer domains when operating in the context of the odn.  This is similarly constructed by not having `is_customer_domain` be false. 
  3.  Reorganizes much of the test file.  See below.
  4.  Fixes a typo in the README that broke apart the endpoints list

#### Testing

`sbt styleCheck test` runs clean.  
 
As y'all know reworking the tests so that every query became a filtered query was a bit gross when trying to keep with the current organization of the `ElasticSearchClientSpec`.  (on that note, sorry for all my griping).   On jason's advice, I basically ripped out all the expected json and started with what was actually returned.  From this, I tried to extract json blocks that were duplicated.  The result sees the creation of more smaller blocks in place of fewer large blocks.

I ran a few queries against shadowprod to check for the correct set of filters in odn and domain contexts and they are as expected. 
