### PR TITLE
rigid mapping "datatype" replaces "_type" polymorphism

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -33,8 +33,8 @@ com.socrata {
     title-boost = 5.0
     function-score-scripts = ["views", "score"]
     type-boosts = {
-      datasets = 10.0
-      datalenses = 5.0
+      dataset = 10.0
+      datalens = 5.0
     }
   }
 }

--- a/src/main/scala/com/socrata/cetera/types/Datatypes.scala
+++ b/src/main/scala/com/socrata/cetera/types/Datatypes.scala
@@ -1,14 +1,16 @@
 package com.socrata.cetera.types
 
 object Datatypes {
-  val all: Seq[Materialized] = Seq(TypeCalendars, TypeCharts, TypeDatalensCharts, TypeDatalenses, TypeDatalensMaps,
-    TypeDatasets, TypeFiles, TypeFilters, TypeForms, TypeGeoMaps, TypeHrefs, TypePulses, TypeTabularMaps)
+  val materialized: Seq[Materialized] = Seq(TypeCalendars, TypeCharts, TypeDatalensCharts,
+    TypeDatalenses, TypeDatalensMaps, TypeDatasets, TypeFiles, TypeFilters, TypeForms,
+    TypeGeoMaps, TypeHrefs, TypePulses, TypeTabularMaps)
+  val all: Seq[DatatypeSimple] = Seq(TypeLinks, TypeMaps) ++ materialized
 }
 
-abstract class DatatypeSimple {
-  def names: Seq[String] = Seq(plural)
+trait DatatypeSimple {
+  def names: Seq[String] = Seq(singular)
   val plural: String
-  def singular: String = plural.dropRight(1)
+  lazy val singular: String = plural.dropRight(1)
 }
 object DatatypeSimple {
   def apply(s: String): Option[DatatypeSimple] = {
@@ -27,7 +29,7 @@ case object TypeCalendars extends DatatypeSimple with Materialized {
 }
 case object TypeDatalenses extends DatatypeSimple with Materialized {
   val plural: String = "datalenses"
-  override val singular: String = "datalens"
+  override lazy val singular: String = "datalens"
 }
 case object TypeDatasets extends DatatypeSimple with Materialized {
   val plural: String = "datasets"
@@ -48,30 +50,36 @@ case object TypePulses extends DatatypeSimple with Materialized {
   val plural: String = "pulses"
 }
 
+// links -> hrefs
+case object TypeLinks extends DatatypeRename {
+  val plural: String = "links"
+  override def names: Seq[String] = TypeHrefs.names
+}
+
 // charts
 case object TypeCharts extends DatatypeRename with Materialized {
   val plural = "charts"
-  override def names: Seq[String] = Seq(TypeCharts.plural, TypeDatalensCharts.plural)
+  override def names: Seq[String] = Seq(TypeCharts.singular, TypeDatalensCharts.singular)
 }
 case object TypeDatalensCharts extends DatatypeRename with Materialized {
   val plural: String = "datalens_charts"
-  override def names: Seq[String] = Seq(TypeCharts.plural, TypeDatalensCharts.plural)
+  override def names: Seq[String] = Seq(TypeCharts.singular, TypeDatalensCharts.singular)
 }
 
 // maps
 case object TypeMaps extends DatatypeRename {
   val plural: String = "maps"
-  override def names: Seq[String] = Seq(TypeDatalensMaps.plural, TypeGeoMaps.plural, TypeTabularMaps.plural)
+  override def names: Seq[String] = Seq(TypeDatalensMaps.singular, TypeGeoMaps.singular, TypeTabularMaps.singular)
 }
 case object TypeDatalensMaps extends DatatypeRename with Materialized {
   val plural: String = "datalens_maps"
-  override def names: Seq[String] = Seq(TypeDatalensMaps.plural, TypeGeoMaps.plural, TypeTabularMaps.plural)
+  override def names: Seq[String] = Seq(TypeDatalensMaps.singular, TypeGeoMaps.singular, TypeTabularMaps.singular)
 }
 case object TypeGeoMaps extends DatatypeRename with Materialized {
   val plural: String = "geo_maps"
-  override def names: Seq[String] = Seq(TypeDatalensMaps.plural, TypeGeoMaps.plural, TypeTabularMaps.plural)
+  override def names: Seq[String] = Seq(TypeDatalensMaps.singular, TypeGeoMaps.singular, TypeTabularMaps.singular)
 }
 case object TypeTabularMaps extends DatatypeRename with Materialized {
   val plural: String = "tabular_maps"
-  override def names: Seq[String] = Seq(TypeDatalensMaps.plural, TypeGeoMaps.plural, TypeTabularMaps.plural)
+  override def names: Seq[String] = Seq(TypeDatalensMaps.singular, TypeGeoMaps.singular, TypeTabularMaps.singular)
 }

--- a/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -105,6 +105,6 @@ case object PageViewsTotalFieldType extends CeteraFieldType {
   val fieldName: String = "page_views.page_views_total"
 }
 
-case object TypeFieldType extends Boostable {
-  val fieldName: String = "_type"
+case object DatatypeFieldType extends Boostable {
+  val fieldName: String = "datatype"
 }

--- a/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
+++ b/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
@@ -117,7 +117,7 @@ object QueryParametersParser {
   def restrictParamFilterType(only: Option[String]): Either[OnlyError, Option[Seq[String]]] =
     only.map { s =>
       DatatypeSimple(s) match {
-        case None => Left(OnlyError(s"'only' must be one of $allowedTypes; got $only"))
+        case None => Left(OnlyError(s"'only' must be one of $allowedTypes; got $s"))
         case Some(d) => Right(Some(d.names))
     }
   }.getOrElse(Right(None))

--- a/src/test/resources/base.json
+++ b/src/test/resources/base.json
@@ -15,6 +15,10 @@
           "type" : "boolean",
           "index": "not_analyzed"
         },
+        "datatype" : {
+          "type" : "string",
+          "index": "not_analyzed"
+        },
         "moderation_status" : {
           "type" : "string",
           "index": "not_analyzed"
@@ -25,25 +29,25 @@
         "update_freq" : {
           "type" : "float"
         },
-        "page_views": {
+        "page_views" : {
           "properties": {
-            "page_views_last_month": {
-              "type": "long"
-            },
-            "page_views_last_month_log": {
-              "type": "double"
-            },
             "page_views_last_week": {
               "type": "long"
             },
-            "page_views_last_week_log": {
-              "type": "double"
+            "page_views_last_month": {
+              "type": "long"
             },
             "page_views_total": {
               "type": "long"
             },
+            "page_views_last_week_log": {
+              "type": "float"
+            },
+            "page_views_last_month_log": {
+              "type": "float"
+            },
             "page_views_total_log": {
-              "type": "double"
+              "type": "float"
             }
           }
         },

--- a/src/test/scala/com/socrata/cetera/search/ElasticSearchClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/ElasticSearchClientSpec.scala
@@ -126,6 +126,8 @@ class ElasticSearchClientSpec extends WordSpec with ShouldMatchers with BeforeAn
       }
   }"""
 
+  val datatypeDatasetsFilter = j"""{ "terms" : { "datatype" : [ "dataset" ] } }"""
+
   val domainFilter = j"""{
     "terms" :
       {
@@ -177,6 +179,7 @@ class ElasticSearchClientSpec extends WordSpec with ShouldMatchers with BeforeAn
       {
         "filters" :
           [
+            ${datatypeDatasetsFilter},
             ${domainFilter},
             ${moderationFilter},
             ${customerDomainFilter},
@@ -326,7 +329,7 @@ class ElasticSearchClientSpec extends WordSpec with ShouldMatchers with BeforeAn
       val actual = JsonReader.fromString(request.toString)
 
       actual should be (expected)
-      request.request.types should be(params.only.get.toArray)
+      request.toString.replaceAll("[\\s\\n]+", " ") should include(datatypeDatasetsFilter.toString())
     }
 
     "sort by categories score when query term is missing but cat filter is present" in {
@@ -384,7 +387,7 @@ class ElasticSearchClientSpec extends WordSpec with ShouldMatchers with BeforeAn
       val actual = JsonReader.fromString(request.toString)
 
       actual should be (expected)
-      request.request.types should be(params.only.get.toArray)
+      request.toString.replaceAll("[\\s\\n]+", " ") should include(datatypeDatasetsFilter.toString())
     }
   }
 

--- a/src/test/scala/com/socrata/cetera/search/TestESDataSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/TestESDataSpec.scala
@@ -45,11 +45,11 @@ class TestESDataSpec extends FunSuiteLike with Matchers with TestESData with Bef
         iom.key -> iom.value.sourceAsMap().asScala
       }
     }
-    mappings.size should be(Datatypes.all.length)
+    mappings.size should be(1)
   }
 
   test("test docs are bootstrapped") {
     val res = client.client.prepareSearch().execute.actionGet
-    res.getHits.getTotalHits should be(Datatypes.all.length)
+    res.getHits.getTotalHits should be(Datatypes.materialized.length)
   }
 }

--- a/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
@@ -7,7 +7,7 @@ import com.socrata.cetera.util.Params
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
 
 class DatatypeBoostSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
-  val client: ElasticSearchClient = new TestESClient(testSuiteName, Map(TypeDatalenses.plural -> 10F))
+  val client: ElasticSearchClient = new TestESClient(testSuiteName, Map(TypeDatalenses.singular -> 10F))
   val service: SearchService = new SearchService(Some(client))
 
   override protected def beforeAll(): Unit = {
@@ -24,8 +24,8 @@ class DatatypeBoostSpec extends FunSuiteLike with Matchers with TestESData with 
       Params.querySimple -> "fourth",
       Params.showScore -> "true"
     ))
-    val oneDatalens = results.results.find(_.resource.dyn.`type`.! == JString(TypeDatalenses.plural)).head
-    val oneOtherThing = results.results.find(_.resource.dyn.`type`.! != JString(TypeDatalenses.plural)).head
+    val oneDatalens = results.results.find(_.resource.dyn.`type`.! == JString(TypeDatalenses.singular)).head
+    val oneOtherThing = results.results.find(_.resource.dyn.`type`.! != JString(TypeDatalenses.singular)).head
 
     val datalensScore: Float = oneDatalens.metadata("score") match {
       case n: JNumber => n.toFloat


### PR DESCRIPTION
* preparing for singular index and singular type mapping
* `_type` is now one value that cetera doesn't care about
* `datatype` is used for `only=` filtering and for boosting

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata/cetera/83)
<!-- Reviewable:end -->
