### PR TITLE
upgrade to elasticsearch 2.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ val loggingDependencies = Seq(
 
 libraryDependencies ++= rojomaDependencies ++ socrataDependencies ++ loggingDependencies ++ Seq(
   "com.typesafe" % "config" % "1.0.2",
+  "org.apache.lucene" % "lucene-expressions" % "5.2.1",
   "org.elasticsearch" % "elasticsearch" % "2.0.2"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val loggingDependencies = Seq(
 
 libraryDependencies ++= rojomaDependencies ++ socrataDependencies ++ loggingDependencies ++ Seq(
   "com.typesafe" % "config" % "1.0.2",
-  "org.elasticsearch" % "elasticsearch" % "1.7.2"
+  "org.elasticsearch" % "elasticsearch" % "2.0.2"
 )
 
 initialCommands := "import com.socrata.cetera._"

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbtassembly.AssemblyPlugin.autoImport._
+
 name := "cetera"
 
 resolvers ++= Seq(
@@ -29,6 +31,14 @@ libraryDependencies ++= rojomaDependencies ++ socrataDependencies ++ loggingDepe
   "com.typesafe" % "config" % "1.0.2",
   "org.elasticsearch" % "elasticsearch" % "2.0.2"
 )
+
+// gosh sbt is a blackhole: joda-time embedded in elasticsearch requires special library shading
+assemblyMergeStrategy in assembly := {
+  case "org/joda/time/base/BaseDateTime.class" => MergeStrategy.first
+  case otherPath =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(otherPath)
+}
 
 initialCommands := "import com.socrata.cetera._"
 

--- a/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -63,7 +63,7 @@ object SearchServer extends App {
       config.elasticSearch.titleBoost,
       config.elasticSearch.minShouldMatch,
       config.elasticSearch.functionScoreScripts.flatMap(fnName =>
-        ScriptScoreFunction.getScriptFunction(fnName)).toSet
+        ScriptScoreFunction.fromName(fnName)).toSet
     )
     val domainClient = new DomainClient(esClient)
 

--- a/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 
 import com.socrata.cetera.config.CeteraConfig
 import com.socrata.cetera.handlers.Router
-import com.socrata.cetera.search.{ElasticSearchClient, DocumentClient, DomainClient}
+import com.socrata.cetera.search.{DocumentClient, DomainClient, ElasticSearchClient}
 import com.socrata.cetera.services._
 import com.socrata.cetera.types.ScriptScoreFunction
 

--- a/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -63,7 +63,7 @@ object SearchServer extends App {
       config.elasticSearch.titleBoost,
       config.elasticSearch.minShouldMatch,
       config.elasticSearch.functionScoreScripts.flatMap(fnName =>
-      ScriptScoreFunction.getScriptFunction(fnName)).toSet
+        ScriptScoreFunction.getScriptFunction(fnName)).toSet
     )
     val domainClient = new DomainClient(esClient)
 

--- a/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -1,7 +1,8 @@
 package com.socrata.cetera.search
 
-import org.elasticsearch.action.search.{SearchType, SearchRequestBuilder}
+import org.elasticsearch.action.search.{SearchRequestBuilder, SearchType}
 import org.elasticsearch.index.query._
+import org.elasticsearch.index.query.functionscore.script.ScriptScoreFunctionBuilder
 import org.elasticsearch.search.aggregations.AggregationBuilders
 import org.elasticsearch.search.sort.{SortBuilders, SortOrder}
 import org.slf4j.LoggerFactory
@@ -18,7 +19,7 @@ object DocumentClient {
     defaultTypeBoosts: Map[String, Float],
     defaultTitleBoost: Option[Float],
     defaultMinShouldMatch: Option[String],
-    scriptScoreFunctions: Set[ScriptScoreFunction]
+    scriptScoreFunctions: Set[ScriptScoreFunctionBuilder]
     ): DocumentClient = {
     val datatypeBoosts = defaultTypeBoosts.flatMap { case (k, v) =>
       DatatypeSimple(k).map(datatype => (datatype, v))
@@ -32,7 +33,7 @@ class DocumentClient(
   defaultTypeBoosts: Map[DatatypeSimple, Float],
   defaultTitleBoost: Option[Float],
   defaultMinShouldMatch: Option[String],
-  scriptScoreFunctions: Set[ScriptScoreFunction]
+  scriptScoreFunctions: Set[ScriptScoreFunctionBuilder]
   ) {
   val logger = LoggerFactory.getLogger(getClass)
 

--- a/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -80,7 +80,7 @@ class DocumentClient(
         slop.foreach(addSlopParam(matchPhrase, _))
 
         // Combines the two queries above into a single Boolean query
-        val q = QueryBuilders.boolQuery().must(matchTerms).should(matchPhrase)
+        val q = QueryBuilders.boolQuery.must(matchTerms).should(matchPhrase)
 
         // If we have typeBoosts, add them as should match clause
         if (typeBoosts.nonEmpty) {
@@ -133,7 +133,7 @@ class DocumentClient(
       if (searchContext.isDefined) domainFilters else odnFilters
     )
     if (filters.nonEmpty) {
-      QueryBuilders.boolQuery()
+      QueryBuilders.boolQuery
         .must(q)
         .filter(filters.toSeq.foldLeft(QueryBuilders.boolQuery) { (q, f) => q.must(f) })
     } else {

--- a/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
@@ -4,20 +4,22 @@ import java.io.Closeable
 
 import org.elasticsearch.client.Client
 import org.elasticsearch.client.transport.TransportClient
-import org.elasticsearch.common.settings.ImmutableSettings
-import org.elasticsearch.common.transport.InetSocketTransportAddress
+import org.elasticsearch.common.settings.Settings
 import org.slf4j.LoggerFactory
 
 class ElasticSearchClient(host: String, port: Int, clusterName: String) extends Closeable {
   val logger = LoggerFactory.getLogger(getClass)
 
-  val settings = ImmutableSettings.settingsBuilder()
+  val settings = Settings.settingsBuilder()
     .put("cluster.name", clusterName)
     .put("client.transport.sniff", true)
-    .build()
+    .put("network.host", host)
+    .put("network.transport.tcp.port", port)
+    .build
 
-  val client: Client = new TransportClient(settings)
-    .addTransportAddress(new InetSocketTransportAddress(host, port))
+  val client: Client = TransportClient.builder()
+    .settings(settings)
+    .build
 
   def close(): Unit = client.close()
 }

--- a/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/ElasticSearchClient.scala
@@ -1,10 +1,12 @@
 package com.socrata.cetera.search
 
 import java.io.Closeable
+import java.net.InetSocketAddress
 
 import org.elasticsearch.client.Client
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.transport.InetSocketTransportAddress
 import org.slf4j.LoggerFactory
 
 class ElasticSearchClient(host: String, port: Int, clusterName: String) extends Closeable {
@@ -13,13 +15,12 @@ class ElasticSearchClient(host: String, port: Int, clusterName: String) extends 
   val settings = Settings.settingsBuilder()
     .put("cluster.name", clusterName)
     .put("client.transport.sniff", true)
-    .put("network.host", host)
-    .put("network.transport.tcp.port", port)
     .build
 
   val client: Client = TransportClient.builder()
     .settings(settings)
     .build
+    .addTransportAddress(new InetSocketTransportAddress(new InetSocketAddress(host, port)))
 
   def close(): Unit = client.close()
 }

--- a/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -42,11 +42,11 @@ object Filters {
 
   def domainMetadataFilter(metadata: Option[Set[(String, String)]]): Option[BoolQueryBuilder] =
     metadata.map { sss =>
-      sss.foldLeft(QueryBuilders.boolQuery().minimumNumberShouldMatch(1)) { (q, kvp) =>
+      sss.foldLeft(QueryBuilders.boolQuery.minimumNumberShouldMatch(1)) { (q, kvp) =>
         q.should(
           QueryBuilders.nestedQuery(
             DomainMetadataFieldType.fieldName,
-            QueryBuilders.boolQuery()
+            QueryBuilders.boolQuery
               .must(QueryBuilders.termsQuery(DomainMetadataFieldType.Key.rawFieldName, kvp._1))
               .must(QueryBuilders.termsQuery(DomainMetadataFieldType.Value.rawFieldName, kvp._2))
           )
@@ -54,17 +54,17 @@ object Filters {
       }
     }
 
-  def customerDomainFilter: Option[NotQueryBuilder] =
-    Some(QueryBuilders.notQuery(QueryBuilders.termsQuery(IsCustomerDomainFieldType.fieldName, "false")))
+  def customerDomainFilter: Option[BoolQueryBuilder] =
+    Some(QueryBuilders.boolQuery.mustNot(QueryBuilders.termsQuery(IsCustomerDomainFieldType.fieldName, "false")))
 
-  def moderationStatusFilter(domainModerated:Boolean = false): Option[NotQueryBuilder] = {
+  def moderationStatusFilter(domainModerated:Boolean = false): Option[BoolQueryBuilder] = {
     val unwantedViews =
       if (domainModerated) {
         QueryBuilders.termsQuery(ModerationStatusFieldType.fieldName, "pending", "rejected", "not_moderated")
       } else {
         QueryBuilders.termsQuery(ModerationStatusFieldType.fieldName, "pending", "rejected")
       }
-    Some(QueryBuilders.notQuery(unwantedViews))
+    Some(QueryBuilders.boolQuery.mustNot(unwantedViews))
   }
 
   def routingApprovalFilter(domain: Option[Domain]): Option[TermsQueryBuilder] = {

--- a/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -5,73 +5,72 @@ import org.elasticsearch.index.query._
 import com.socrata.cetera.types._
 
 object Filters {
-  def datatypeFilter(datatypes: Option[Seq[String]]): Option[TermsFilterBuilder] =
+  def datatypeFilter(datatypes: Option[Seq[String]]): Option[TermsQueryBuilder] =
     datatypes.map { ts =>
       val validatedDatatypes = ts.map(t => DatatypeSimple(t).map(_.singular)).flatten
-      FilterBuilders.termsFilter(DatatypeFieldType.fieldName, validatedDatatypes: _*)
+      QueryBuilders.termsQuery(DatatypeFieldType.fieldName, validatedDatatypes: _*)
     }
 
-  def domainFilter(domains: Option[Set[String]]): Option[TermsFilterBuilder] =
-    domains.map { ds => FilterBuilders.termsFilter(DomainFieldType.rawFieldName, ds.toSeq: _*) }
+  def domainFilter(domains: Option[Set[String]]): Option[TermsQueryBuilder] =
+    domains.map { ds => QueryBuilders.termsQuery(DomainFieldType.rawFieldName, ds.toSeq: _*) }
 
-  def categoriesFilter(categories: Option[Set[String]]): Option[NestedFilterBuilder] =
+  def categoriesFilter(categories: Option[Set[String]]): Option[NestedQueryBuilder] =
     categories.map { cs =>
-      FilterBuilders.nestedFilter(
+      QueryBuilders.nestedQuery(
         CategoriesFieldType.fieldName,
-        FilterBuilders.termsFilter(CategoriesFieldType.Name.rawFieldName, cs.toSeq: _*)
+        QueryBuilders.termsQuery(CategoriesFieldType.Name.rawFieldName, cs.toSeq: _*)
       )
     }
 
-  def tagsFilter(tags: Option[Set[String]]): Option[NestedFilterBuilder] =
+  def tagsFilter(tags: Option[Set[String]]): Option[NestedQueryBuilder] =
     tags.map { tags =>
-      FilterBuilders.nestedFilter(
+      QueryBuilders.nestedQuery(
         TagsFieldType.fieldName,
-        FilterBuilders.termsFilter(TagsFieldType.Name.rawFieldName, tags.toSeq: _*)
+        QueryBuilders.termsQuery(TagsFieldType.Name.rawFieldName, tags.toSeq: _*)
       )
     }
 
-  def domainCategoriesFilter(categories: Option[Set[String]]): Option[TermsFilterBuilder] =
+  def domainCategoriesFilter(categories: Option[Set[String]]): Option[TermsQueryBuilder] =
     categories.map { cs =>
-      FilterBuilders.termsFilter(DomainCategoryFieldType.rawFieldName, cs.toSeq: _*)
+      QueryBuilders.termsQuery(DomainCategoryFieldType.rawFieldName, cs.toSeq: _*)
     }
 
-  def domainTagsFilter(tags: Option[Set[String]]): Option[TermsFilterBuilder] =
+  def domainTagsFilter(tags: Option[Set[String]]): Option[TermsQueryBuilder] =
     tags.map { ts =>
-      FilterBuilders.termsFilter(DomainTagsFieldType.rawFieldName, ts.toSeq: _*)
+      QueryBuilders.termsQuery(DomainTagsFieldType.rawFieldName, ts.toSeq: _*)
     }
 
-  def domainMetadataFilter(metadata: Option[Set[(String, String)]]): Option[OrFilterBuilder] =
-    metadata.map { ss =>
-      FilterBuilders.orFilter(
-        ss.map { kvp =>
-          FilterBuilders.nestedFilter(
+  def domainMetadataFilter(metadata: Option[Set[(String, String)]]): Option[BoolQueryBuilder] =
+    metadata.map { sss =>
+      sss.foldLeft(QueryBuilders.boolQuery().minimumNumberShouldMatch(1)) { (q, kvp) =>
+        q.should(
+          QueryBuilders.nestedQuery(
             DomainMetadataFieldType.fieldName,
-            FilterBuilders.andFilter(
-              FilterBuilders.termsFilter(DomainMetadataFieldType.Key.rawFieldName, kvp._1),
-              FilterBuilders.termsFilter(DomainMetadataFieldType.Value.rawFieldName, kvp._2)
-            )
+            QueryBuilders.boolQuery()
+              .must(QueryBuilders.termsQuery(DomainMetadataFieldType.Key.rawFieldName, kvp._1))
+              .must(QueryBuilders.termsQuery(DomainMetadataFieldType.Value.rawFieldName, kvp._2))
           )
-        }.toSeq: _*
-      )
+        )
+      }
     }
 
-  def customerDomainFilter: Option[NotFilterBuilder] =
-    Some(FilterBuilders.notFilter(FilterBuilders.termsFilter(IsCustomerDomainFieldType.fieldName, "false")))
+  def customerDomainFilter: Option[NotQueryBuilder] =
+    Some(QueryBuilders.notQuery(QueryBuilders.termsQuery(IsCustomerDomainFieldType.fieldName, "false")))
 
-  def moderationStatusFilter(domainModerated:Boolean = false): Option[NotFilterBuilder] = {
+  def moderationStatusFilter(domainModerated:Boolean = false): Option[NotQueryBuilder] = {
     val unwantedViews =
       if (domainModerated) {
-        FilterBuilders.termsFilter(ModerationStatusFieldType.fieldName, "pending", "rejected", "not_moderated")
+        QueryBuilders.termsQuery(ModerationStatusFieldType.fieldName, "pending", "rejected", "not_moderated")
       } else {
-        FilterBuilders.termsFilter(ModerationStatusFieldType.fieldName, "pending", "rejected")
+        QueryBuilders.termsQuery(ModerationStatusFieldType.fieldName, "pending", "rejected")
       }
-    Some(FilterBuilders.notFilter(unwantedViews))
+    Some(QueryBuilders.notQuery(unwantedViews))
   }
 
-  def routingApprovalFilter(domain: Option[Domain]): Option[TermsFilterBuilder] = {
+  def routingApprovalFilter(domain: Option[Domain]): Option[TermsQueryBuilder] = {
     domain.flatMap { d =>
       if (d.routingApprovalEnabled) {
-        Some(FilterBuilders.termsFilter(ApprovingDomainsFieldType.fieldName, d.domainCname))
+        Some(QueryBuilders.termsQuery(ApprovingDomainsFieldType.fieldName, d.domainCname))
       } else {
         None
       }

--- a/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
+++ b/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
@@ -12,10 +12,10 @@ object SundryBuilders {
 
   def addSlopParam(query: MultiMatchQueryBuilder, slop: Int): MultiMatchQueryBuilder = query.slop(slop)
 
-  def addFunctionScores(scriptScoreFunctions:Set[ScriptScoreFunction],
+  def addFunctionScores(scriptScoreFunctions: Set[ScriptScoreFunction],
                         query: FunctionScoreQueryBuilder): FunctionScoreQueryBuilder = {
     scriptScoreFunctions.foreach { fn =>
-      query.add(ScoreFunctionBuilders.scriptFunction(fn.script, "expression"))
+      query.add(ScoreFunctionBuilders.scriptFunction(fn.script))
     }
 
     // Take a product of scores and replace original score with product
@@ -24,9 +24,7 @@ object SundryBuilders {
 
   def boostTypes(typeBoosts: Map[DatatypeSimple, Float]): BoolQueryBuilder = {
     typeBoosts.foldLeft(QueryBuilders.boolQuery()) { case (q, (datatype, boost)) =>
-      typeBoosts.foldLeft(QueryBuilders.boolQuery()) { case (q, (datatype, boost)) =>
-        q.should(QueryBuilders.termQuery(DatatypeFieldType.fieldName, datatype.singular).boost(boost))
-      }
+      q.should(QueryBuilders.termQuery(DatatypeFieldType.fieldName, datatype.singular).boost(boost))
     }
   }
 

--- a/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
+++ b/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
@@ -22,7 +22,7 @@ object SundryBuilders {
   }
 
   def boostTypes(typeBoosts: Map[DatatypeSimple, Float]): BoolQueryBuilder = {
-    typeBoosts.foldLeft(QueryBuilders.boolQuery()) { case (q, (datatype, boost)) =>
+    typeBoosts.foldLeft(QueryBuilders.boolQuery) { case (q, (datatype, boost)) =>
       q.should(QueryBuilders.termQuery(DatatypeFieldType.fieldName, datatype.singular).boost(boost))
     }
   }

--- a/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
+++ b/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
@@ -1,10 +1,11 @@
 package com.socrata.cetera.search
 
-import org.elasticsearch.index.query.functionscore.{ScoreFunctionBuilders, FunctionScoreQueryBuilder}
-import org.elasticsearch.index.query.{BoolQueryBuilder, QueryBuilders, MultiMatchQueryBuilder}
-import org.elasticsearch.search.sort.{SortOrder, SortBuilders, SortBuilder}
+import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder
+import org.elasticsearch.index.query.functionscore.script.ScriptScoreFunctionBuilder
+import org.elasticsearch.index.query.{BoolQueryBuilder, MultiMatchQueryBuilder, QueryBuilders}
+import org.elasticsearch.search.sort.{SortBuilder, SortBuilders, SortOrder}
 
-import com.socrata.cetera.types.{ScriptScoreFunction, DatatypeFieldType, DatatypeSimple}
+import com.socrata.cetera.types.{DatatypeFieldType, DatatypeSimple}
 
 object SundryBuilders {
   def addMinMatchConstraint(query: MultiMatchQueryBuilder, constraint: String): MultiMatchQueryBuilder =
@@ -12,11 +13,9 @@ object SundryBuilders {
 
   def addSlopParam(query: MultiMatchQueryBuilder, slop: Int): MultiMatchQueryBuilder = query.slop(slop)
 
-  def addFunctionScores(scriptScoreFunctions: Set[ScriptScoreFunction],
+  def addFunctionScores(scriptScoreFunctions: Set[ScriptScoreFunctionBuilder],
                         query: FunctionScoreQueryBuilder): FunctionScoreQueryBuilder = {
-    scriptScoreFunctions.foreach { fn =>
-      query.add(ScoreFunctionBuilders.scriptFunction(fn.script))
-    }
+    scriptScoreFunctions.foreach { script => query.add(script) }
 
     // Take a product of scores and replace original score with product
     query.scoreMode("multiply").boostMode("replace")

--- a/src/main/scala/com/socrata/cetera/services/FacetService.scala
+++ b/src/main/scala/com/socrata/cetera/services/FacetService.scala
@@ -55,23 +55,23 @@ class FacetService(documentClient: DocumentClient) {
       .getAggregations.asMap().asScala
 
     val datatypesValues = aggs("datatypes").asInstanceOf[Terms]
-      .getBuckets.asScala.map(b => ValueCount(b.getKey, b.getDocCount)).toSeq.filter(_.value.nonEmpty)
+      .getBuckets.asScala.map(b => ValueCount(b.getKeyAsString, b.getDocCount)).toSeq.filter(_.value.nonEmpty)
     val datatypesFacets = Seq(FacetCount("datatypes", datatypesValues.map(_.count).sum, datatypesValues))
 
     val categoriesValues = aggs("categories").asInstanceOf[Terms]
-      .getBuckets.asScala.map(b => ValueCount(b.getKey, b.getDocCount)).toSeq.filter(_.value.nonEmpty)
+      .getBuckets.asScala.map(b => ValueCount(b.getKeyAsString, b.getDocCount)).toSeq.filter(_.value.nonEmpty)
     val categoriesFacets = Seq(FacetCount("categories", categoriesValues.map(_.count).sum, categoriesValues))
 
     val tagsValues = aggs("tags").asInstanceOf[Terms]
-      .getBuckets.asScala.map(b => ValueCount(b.getKey, b.getDocCount)).toSeq.filter(_.value.nonEmpty)
+      .getBuckets.asScala.map(b => ValueCount(b.getKeyAsString, b.getDocCount)).toSeq.filter(_.value.nonEmpty)
     val tagsFacets = Seq(FacetCount("tags", tagsValues.map(_.count).sum, tagsValues))
 
     val metadataFacets = aggs("metadata").asInstanceOf[Nested]
       .getAggregations.get("keys").asInstanceOf[Terms]
       .getBuckets.asScala.map { b =>
         val values = b.getAggregations.get("values").asInstanceOf[Terms]
-          .getBuckets.asScala.map { v => ValueCount(v.getKey, v.getDocCount) }.toSeq
-        FacetCount(b.getKey, b.getDocCount, values)
+          .getBuckets.asScala.map { v => ValueCount(v.getKeyAsString, v.getDocCount) }.toSeq
+        FacetCount(b.getKeyAsString, b.getDocCount, values)
       }.toSeq
 
     val facets: Seq[FacetCount] = Seq.concat(datatypesFacets, categoriesFacets, tagsFacets, metadataFacets)

--- a/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -135,7 +135,7 @@ class SearchService(elasticSearchClient: DocumentClient, domainClient: DomainCli
         throw new IllegalArgumentException(s"Invalid query parameters: $msg")
 
       case Right(params) =>
-        val domain = params.searchContext.flatMap(domainClient.getDomain(_))
+        val domain = params.searchContext.flatMap(domainClient.getDomain)
         val res = elasticSearchClient.buildSearchRequest(
           params.searchQuery,
           params.domains,

--- a/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -8,12 +8,12 @@ import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonKeyStrategy, Stra
 import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
 import com.socrata.http.server.routing.SimpleResource
-import com.socrata.http.server.{HttpResponse, HttpRequest, HttpService}
+import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import org.elasticsearch.action.search.SearchResponse
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.search.{DomainClient, DocumentClient}
+import com.socrata.cetera.search.{DocumentClient, DomainClient}
 import com.socrata.cetera.types._
 import com.socrata.cetera.util.JsonResponses._
 import com.socrata.cetera.util._

--- a/src/main/scala/com/socrata/cetera/types/QueryType.scala
+++ b/src/main/scala/com/socrata/cetera/types/QueryType.scala
@@ -19,10 +19,21 @@ object MinShouldMatch {
 case class ScriptScoreFunction(script: String)
 
 object ScriptScoreFunction {
+  private def script(script: String, lang: String = "expression"): ScriptScoreFunction =
+    ScriptScoreFunction(s"""
+      |"script": {
+      |  "lang": "$lang",
+      |  "inline": "$script"
+      |}
+    """.stripMargin)
+
+  protected val VIEWS = script("1 + doc['page_views.page_views_total_log'].value")
+  protected val SCORE = script("_score")
+
   def getScriptFunction(name: String): Option[ScriptScoreFunction] =
     name match {
-      case "views" => Option(ScriptScoreFunction("""1 + doc["page_views.page_views_total_log"].value"""))
-      case "score" => Option(ScriptScoreFunction("_score"))
+      case "views" => Option(VIEWS)
+      case "score" => Option(SCORE)
       case _ => None // log this?
     }
 }

--- a/src/test/resources/base.json
+++ b/src/test/resources/base.json
@@ -63,37 +63,42 @@
           "properties" : {
             "columns_description" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "columns_name" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "columns_field_name" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "description" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "name" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             }
           },
@@ -101,7 +106,6 @@
         },
         "resource" : {
           "enabled" : false,
-          "index" : "no",
           "type" : "nested",
           "properties" : {
             "page_views" : {
@@ -137,23 +141,26 @@
             },
             "columns_description" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "columns_name" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "columns_field_name" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             }
           }
@@ -166,9 +173,10 @@
             "domain_cname" : {
               "type" : "string",
               "analyzer" : "simple",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "domain_id" : {
@@ -176,16 +184,18 @@
             },
             "organization" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "site_title" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             }
           },
@@ -198,9 +208,10 @@
               "properties" : {
                 "name" : {
                   "type" : "string",
+                  "copy_to": [ "fts_analyzed", "fts_raw" ],
                   "fields" : {
-                    "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                    "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                    "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
+                    "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
                   }
                 },
                 "score" : {"type" : "float", "store" : "no", "index" : "not_analyzed"}
@@ -211,9 +222,10 @@
               "properties" : {
                 "name" : {
                   "type" : "string",
+                  "copy_to": [ "fts_analyzed", "fts_raw" ],
                   "fields" : {
-                    "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                    "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                    "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
+                    "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
                   }
                 },
                 "score" : {"type" : "float", "store" : "no", "index" : "not_analyzed"}
@@ -223,16 +235,18 @@
         },
         "customer_tags" : {
           "type" : "string",
+          "copy_to": [ "fts_analyzed", "fts_raw" ],
           "fields": {
-            "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-            "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+            "raw" : {"type" : "string", "index" : "not_analyzed"},
+            "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
           }
         },
         "customer_category" : {
           "type" : "string",
+          "copy_to": [ "fts_analyzed", "fts_raw" ],
           "fields" : {
-            "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-            "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+            "raw" : {"type" : "string", "index" : "not_analyzed"},
+            "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
           }
         },
         "customer_metadata_flattened" : {
@@ -240,16 +254,18 @@
           "properties" : {
             "key" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "value" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             }
           }

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -94,9 +94,9 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   }"""
 
   val moderationFilter = j"""{
-    "not" :
+    "bool" :
       {
-        "query" :
+        "must_not" :
           {
             "terms" :
               {
@@ -108,9 +108,9 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   }"""
 
   val customerDomainFilter = j"""{
-    "not" :
+    "bool" :
       {
-        "query" :
+        "must_not" :
           {
             "terms" : {
                         "is_customer_domain" : [ "false" ]

--- a/src/test/scala/com/socrata/cetera/search/TestESClient.scala
+++ b/src/test/scala/com/socrata/cetera/search/TestESClient.scala
@@ -3,17 +3,18 @@ package com.socrata.cetera.search
 import java.io.File
 import java.nio.file.Files
 
-import org.elasticsearch.common.settings.ImmutableSettings
+import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.node.NodeBuilder._
 
 class TestESClient(val clusterName: String) extends ElasticSearchClient("local", 0, "useless") {
 
   val tempDataDir = Files.createTempDirectory("elasticsearch_data_").toFile
-  val testSettings = ImmutableSettings.settingsBuilder()
+  val testSettings = Settings.settingsBuilder()
     .put("cluster.name", clusterName)
     .put("client.transport.sniff", false)
     .put("discovery.zen.ping.multicast.enabled", false)
     .put("path.data", tempDataDir.toString)
+    .put("path.home", tempDataDir.getParent)
     .build
   val node = nodeBuilder().settings(testSettings).local(true).node()
 

--- a/src/test/scala/com/socrata/cetera/search/TestESClient.scala
+++ b/src/test/scala/com/socrata/cetera/search/TestESClient.scala
@@ -6,7 +6,7 @@ import java.nio.file.Files
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.node.NodeBuilder._
 
-class TestESClient(val clusterName: String) extends ElasticSearchClient("local", 0, "useless") {
+class TestESClient(val clusterName: String) extends ElasticSearchClient("localhost", 9301, "useless") {
 
   val tempDataDir = Files.createTempDirectory("elasticsearch_data_").toFile
   val testSettings = Settings.settingsBuilder()

--- a/src/test/scala/com/socrata/cetera/search/TestESData.scala
+++ b/src/test/scala/com/socrata/cetera/search/TestESData.scala
@@ -4,7 +4,7 @@ import scala.io.Source
 
 import com.rojoma.json.v3.ast.JValue
 import com.rojoma.json.v3.util.JsonUtil
-import org.elasticsearch.common.joda.time.DateTime
+import org.joda.time.DateTime
 import org.scalatest.exceptions.TestCanceledException
 
 import com.socrata.cetera._
@@ -275,7 +275,6 @@ trait TestESData {
       .execute.actionGet
     client.client.admin().indices().preparePutMapping(testSuiteName)
       .setType(esDocumentType).setSource(datatypeMappings)
-      .setIgnoreConflicts(true)
       .execute.actionGet
     Indices.foreach { alias =>
       client.client.admin().indices().prepareAliases()

--- a/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -4,9 +4,6 @@ import scala.collection.JavaConverters._
 
 import com.rojoma.json.v3.ast.{JString, JValue}
 import com.rojoma.json.v3.interpolation._
-import com.socrata.cetera._
-import com.socrata.cetera.search._
-import com.socrata.cetera.types._
 import org.elasticsearch.action.search._
 import org.elasticsearch.common.bytes.BytesArray
 import org.elasticsearch.common.text.StringText
@@ -16,6 +13,10 @@ import org.elasticsearch.search.internal._
 import org.elasticsearch.search.suggest.Suggest
 import org.elasticsearch.search.{SearchHitField, SearchShardTarget}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+
+import com.socrata.cetera._
+import com.socrata.cetera.search._
+import com.socrata.cetera.types._
 
 class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAll {
   val client: ElasticSearchClient = new TestESClient("SearchService")

--- a/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -11,7 +11,6 @@ import org.elasticsearch.action.search._
 import org.elasticsearch.common.bytes.BytesArray
 import org.elasticsearch.common.text.StringText
 import org.elasticsearch.search.aggregations.{InternalAggregation, InternalAggregations}
-import org.elasticsearch.search.facet.{Facet, InternalFacets}
 import org.elasticsearch.search.internal._
 import org.elasticsearch.search.suggest.Suggest
 import org.elasticsearch.search.{SearchHitField, SearchShardTarget}
@@ -68,7 +67,6 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
     val internalSearchHits = new InternalSearchHits(hits, 3037, 1.0f)
     val internalSearchResponse = new InternalSearchResponse(
       internalSearchHits,
-      new InternalFacets(List[Facet]().asJava),
       new InternalAggregations(List[InternalAggregation]().asJava),
       new Suggest(),
       false,

--- a/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -10,6 +10,7 @@ import com.socrata.cetera.types._
 import org.elasticsearch.action.search._
 import org.elasticsearch.common.bytes.BytesArray
 import org.elasticsearch.common.text.StringText
+import org.elasticsearch.index.query.functionscore.script.ScriptScoreFunctionBuilder
 import org.elasticsearch.search.aggregations.{InternalAggregation, InternalAggregations}
 import org.elasticsearch.search.internal._
 import org.elasticsearch.search.suggest.Suggest
@@ -202,7 +203,8 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
 
 class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
-  val documentClient: DocumentClient = DocumentClient(client, Map.empty, None, None, Set.empty)
+  val scripts: Set[ScriptScoreFunctionBuilder] = Set("views", "score").flatMap(ScriptScoreFunction.fromName)
+  val documentClient: DocumentClient = DocumentClient(client, Map.empty, None, None, scripts)
   val domainClient: DomainClient = new DomainClient(client)
   val service: SearchService = new SearchService(documentClient, domainClient)
 


### PR DESCRIPTION
many 1.x features are now deprecated in 2.x:
- facets are dead and gone
- all filters replaced with queries
- filteredQuery, andQuery, orQuery, notQuery all replaced with new query dsl boolQuery and must/mustNot/should/filter
- mapping does not allow multi-field copies
- settings builder updated
- new inline script format
- count query is replaced by query then fetch with size=0

PLEASE DON'T MERGE QUITE YET - requires etl update as well, for the mappings of course.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata/cetera/98)

<!-- Reviewable:end -->
