### PR TITLE
static analysis via codacy

### DIFF
--- a/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 
 import com.socrata.cetera.config.CeteraConfig
 import com.socrata.cetera.handlers.Router
-import com.socrata.cetera.search.{ElasticSearchClient, DocumentClient, DomainClient}
+import com.socrata.cetera.search.{DocumentClient, DomainClient, ElasticSearchClient}
 import com.socrata.cetera.services._
 import com.socrata.cetera.types.ScriptScoreFunction
 

--- a/src/main/scala/com/socrata/cetera/config/AppConfig.scala
+++ b/src/main/scala/com/socrata/cetera/config/AppConfig.scala
@@ -1,6 +1,5 @@
 package com.socrata.cetera.config
 
-import com.socrata.thirdparty.curator.{CuratorConfig, DiscoveryConfig}
 import com.socrata.thirdparty.typesafeconfig.ConfigClass
 import com.typesafe.config.Config
 

--- a/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -21,7 +21,7 @@ object DocumentClient {
     scriptScoreFunctions: Set[ScriptScoreFunction]
     ): DocumentClient = {
     val datatypeBoosts = defaultTypeBoosts.flatMap { case (k, v) =>
-      DatatypeSimple(k).map(datatype => (datatype, v))
+      Datatype(k).map(datatype => (datatype, v))
     }
     new DocumentClient(esClient, datatypeBoosts, defaultTitleBoost, defaultMinShouldMatch, scriptScoreFunctions)
   }
@@ -29,7 +29,7 @@ object DocumentClient {
 
 class DocumentClient(
   esClient: ElasticSearchClient,
-  defaultTypeBoosts: Map[DatatypeSimple, Float],
+  defaultTypeBoosts: Map[Datatype, Float],
   defaultTitleBoost: Option[Float],
   defaultMinShouldMatch: Option[String],
   scriptScoreFunctions: Set[ScriptScoreFunction]
@@ -58,7 +58,7 @@ class DocumentClient(
   def generateQuery(
     searchQuery: QueryType,
     fieldBoosts: Map[CeteraFieldType with Boostable, Float],
-    typeBoosts: Map[DatatypeSimple, Float],
+    typeBoosts: Map[Datatype, Float],
     minShouldMatch: Option[String],
     slop: Option[Int]
   ): BaseQueryBuilder = {
@@ -148,7 +148,7 @@ class DocumentClient(
     domainMetadata: Option[Set[(String, String)]],
     only: Option[Seq[String]],
     fieldBoosts: Map[CeteraFieldType with Boostable, Float],
-    datatypeBoosts: Map[DatatypeSimple, Float],
+    datatypeBoosts: Map[Datatype, Float],
     minShouldMatch: Option[String],
     slop: Option[Int]
   ): SearchRequestBuilder = {
@@ -190,7 +190,7 @@ class DocumentClient(
     tags: Option[Set[String]],
     only: Option[Seq[String]],
     fieldBoosts: Map[CeteraFieldType with Boostable, Float],
-    datatypeBoosts: Map[DatatypeSimple, Float],
+    datatypeBoosts: Map[Datatype, Float],
     minShouldMatch: Option[String],
     slop: Option[Int],
     offset: Int,

--- a/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -2,7 +2,7 @@ package com.socrata.cetera.search
 
 import com.rojoma.json.v3.codec.JsonDecode
 import com.rojoma.json.v3.io.JsonReader
-import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, Strategy, JsonKeyStrategy}
+import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonKeyStrategy, Strategy}
 import org.elasticsearch.index.query._
 import org.slf4j.LoggerFactory
 

--- a/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -25,14 +25,14 @@ class DomainClient(val esClient: ElasticSearchClient) {
   val logger = LoggerFactory.getLogger(getClass)
   val baseRequest = esClient.client.prepareSearch(Indices: _*)
 
-  def getDomain(cname: String): Option[Domain] = {
+  def find(cname: String): Option[Domain] = {
     val query = baseRequest.setQuery(QueryBuilders.idsQuery(esDomainType).addIds(cname))
     val res = query.execute.actionGet
     val hits = res.getHits.hits
     hits.length match {
       case 0 => None
       case n: Int =>
-        val domainAsJvalue = JsonReader.fromString(hits(0).getSourceAsString())
+        val domainAsJvalue = JsonReader.fromString(hits(0).getSourceAsString)
         val domainDecode = JsonDecode.fromJValue[Domain](domainAsJvalue)
         domainDecode match {
           case Right(domain) => Some(domain)

--- a/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -43,12 +43,12 @@ object Filters {
   def domainMetadataFilter(metadata: Option[Set[(String, String)]]): Option[OrFilterBuilder] =
     metadata.map { ss =>
       FilterBuilders.orFilter(
-        ss.map { kvp =>
+        ss.map { case (key, value) =>
           FilterBuilders.nestedFilter(
             DomainMetadataFieldType.fieldName,
             FilterBuilders.andFilter(
-              FilterBuilders.termsFilter(DomainMetadataFieldType.Key.rawFieldName, kvp._1),
-              FilterBuilders.termsFilter(DomainMetadataFieldType.Value.rawFieldName, kvp._2)
+              FilterBuilders.termsFilter(DomainMetadataFieldType.Key.rawFieldName, key),
+              FilterBuilders.termsFilter(DomainMetadataFieldType.Value.rawFieldName, value)
             )
           )
         }.toSeq: _*

--- a/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -7,7 +7,7 @@ import com.socrata.cetera.types._
 object Filters {
   def datatypeFilter(datatypes: Option[Seq[String]]): Option[TermsFilterBuilder] =
     datatypes.map { ts =>
-      val validatedDatatypes = ts.map(t => DatatypeSimple(t).map(_.singular)).flatten
+      val validatedDatatypes = ts.map(t => Datatype(t).map(_.singular)).flatten
       FilterBuilders.termsFilter(DatatypeFieldType.fieldName, validatedDatatypes: _*)
     }
 

--- a/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
+++ b/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
@@ -1,10 +1,10 @@
 package com.socrata.cetera.search
 
-import org.elasticsearch.index.query.functionscore.{ScoreFunctionBuilders, FunctionScoreQueryBuilder}
-import org.elasticsearch.index.query.{BoolQueryBuilder, QueryBuilders, MultiMatchQueryBuilder}
-import org.elasticsearch.search.sort.{SortOrder, SortBuilders, SortBuilder}
+import org.elasticsearch.index.query.functionscore.{FunctionScoreQueryBuilder, ScoreFunctionBuilders}
+import org.elasticsearch.index.query.{BoolQueryBuilder, MultiMatchQueryBuilder, QueryBuilders}
+import org.elasticsearch.search.sort.{SortBuilder, SortBuilders, SortOrder}
 
-import com.socrata.cetera.types.{ScriptScoreFunction, DatatypeFieldType, DatatypeSimple}
+import com.socrata.cetera.types.{DatatypeFieldType, DatatypeSimple, ScriptScoreFunction}
 
 object SundryBuilders {
   def addMinMatchConstraint(query: MultiMatchQueryBuilder, constraint: String): MultiMatchQueryBuilder =

--- a/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
+++ b/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
@@ -4,7 +4,7 @@ import org.elasticsearch.index.query.functionscore.{FunctionScoreQueryBuilder, S
 import org.elasticsearch.index.query.{BoolQueryBuilder, MultiMatchQueryBuilder, QueryBuilders}
 import org.elasticsearch.search.sort.{SortBuilder, SortBuilders, SortOrder}
 
-import com.socrata.cetera.types.{DatatypeFieldType, DatatypeSimple, ScriptScoreFunction}
+import com.socrata.cetera.types.{DatatypeFieldType, Datatype, ScriptScoreFunction}
 
 object SundryBuilders {
   def addMinMatchConstraint(query: MultiMatchQueryBuilder, constraint: String): MultiMatchQueryBuilder =
@@ -22,7 +22,7 @@ object SundryBuilders {
     query.scoreMode("multiply").boostMode("replace")
   }
 
-  def boostTypes(typeBoosts: Map[DatatypeSimple, Float]): BoolQueryBuilder = {
+  def boostTypes(typeBoosts: Map[Datatype, Float]): BoolQueryBuilder = {
     typeBoosts.foldLeft(QueryBuilders.boolQuery()) { case (q, (datatype, boost)) =>
       typeBoosts.foldLeft(QueryBuilders.boolQuery()) { case (q, (datatype, boost)) =>
         q.should(QueryBuilders.termQuery(DatatypeFieldType.fieldName, datatype.singular).boost(boost))

--- a/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -44,7 +44,7 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
         throw new IllegalArgumentException(s"Invalid query parameters: $msg")
 
       case Right(params) =>
-        val domain = params.searchContext.flatMap(domainClient.getDomain)
+        val domain = params.searchContext.flatMap(domainClient.find)
         val res = documentClient.buildCountRequest(
           field,
           params.searchQuery,

--- a/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -11,7 +11,7 @@ import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.search.{DomainClient, DocumentClient}
+import com.socrata.cetera.search.{DocumentClient, DomainClient}
 import com.socrata.cetera.types._
 import com.socrata.cetera.util.JsonResponses._
 import com.socrata.cetera.util._

--- a/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -1,5 +1,7 @@
 package com.socrata.cetera.services
 
+import scala.util.control.NonFatal
+
 import com.rojoma.json.v3.ast.JValue
 import com.rojoma.json.v3.codec.DecodeError
 import com.rojoma.json.v3.io.JsonReader
@@ -83,7 +85,7 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
       case e: IllegalArgumentException =>
         logger.info(e.getMessage)
         BadRequest ~> HeaderAclAllowOriginAll ~> jsonError(e.getMessage)
-      case e: Exception =>
+      case NonFatal(e) =>
         val esError = ElasticsearchError(e)
         logger.error(s"Database error: ${esError.getMessage}")
         InternalServerError ~> HeaderAclAllowOriginAll ~> jsonError(s"Database error", esError)

--- a/src/main/scala/com/socrata/cetera/services/FacetService.scala
+++ b/src/main/scala/com/socrata/cetera/services/FacetService.scala
@@ -1,6 +1,7 @@
 package com.socrata.cetera.services
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
@@ -36,7 +37,7 @@ class FacetService(documentClient: DocumentClient) {
           logger.info(LogHelper.formatRequest(req, timings))
           OK ~> HeaderAclAllowOriginAll ~> Json(facets)
         } catch {
-          case e: Exception =>
+          case NonFatal(e) =>
             val esError = ElasticsearchError(e)
             logger.error(s"Database error: ${esError.getMessage}")
             InternalServerError ~> HeaderAclAllowOriginAll ~> jsonError(s"Database error", esError)

--- a/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -89,8 +89,8 @@ class SearchService(elasticSearchClient: DocumentClient, domainClient: DomainCli
       case _ => None
     })
 
-  private def datatype(j: JValue): Option[DatatypeSimple] =
-    extractJString(j.dyn.datatype.?).flatMap(s => DatatypeSimple(s))
+  private def datatype(j: JValue): Option[Datatype] =
+    extractJString(j.dyn.datatype.?).flatMap(s => Datatype(s))
 
   private def viewtype(j: JValue): Option[String] = extractJString(j.dyn.viewtype.?)
 
@@ -186,7 +186,7 @@ class SearchService(elasticSearchClient: DocumentClient, domainClient: DomainCli
 
 object SearchService {
   def links(cname: String,
-             datatype: Option[DatatypeSimple],
+             datatype: Option[Datatype],
              viewtype: Option[String],
              datasetId: String,
              datasetCategory: Option[String],

--- a/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -135,7 +135,7 @@ class SearchService(elasticSearchClient: DocumentClient, domainClient: DomainCli
         throw new IllegalArgumentException(s"Invalid query parameters: $msg")
 
       case Right(params) =>
-        val domain = params.searchContext.flatMap(domainClient.getDomain)
+        val domain = params.searchContext.flatMap(domainClient.find)
         val res = elasticSearchClient.buildSearchRequest(
           params.searchQuery,
           params.domains,

--- a/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -8,12 +8,12 @@ import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonKeyStrategy, Stra
 import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
 import com.socrata.http.server.routing.SimpleResource
-import com.socrata.http.server.{HttpResponse, HttpRequest, HttpService}
+import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import org.elasticsearch.action.search.SearchResponse
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.search.{DomainClient, DocumentClient}
+import com.socrata.cetera.search.{DocumentClient, DomainClient}
 import com.socrata.cetera.types._
 import com.socrata.cetera.util.JsonResponses._
 import com.socrata.cetera.util._

--- a/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -1,5 +1,7 @@
 package com.socrata.cetera.services
 
+import scala.util.control.NonFatal
+
 import com.rojoma.json.v3.ast._
 import com.rojoma.json.v3.codec.DecodeError
 import com.rojoma.json.v3.io.JsonReader
@@ -171,7 +173,7 @@ class SearchService(elasticSearchClient: DocumentClient, domainClient: DomainCli
       case e: IllegalArgumentException =>
         logger.info(e.getMessage)
         BadRequest ~> HeaderAclAllowOriginAll ~> jsonError(e.getMessage)
-      case e: Exception =>
+      case NonFatal(e) =>
         val esError = ElasticsearchError(e)
         logger.error(s"Database error: ${esError.getMessage}")
         InternalServerError ~> HeaderAclAllowOriginAll ~> jsonError(s"Database error", esError)

--- a/src/main/scala/com/socrata/cetera/services/VersionService.scala
+++ b/src/main/scala/com/socrata/cetera/services/VersionService.scala
@@ -3,7 +3,7 @@ package com.socrata.cetera.services
 import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
 import com.socrata.http.server.routing.SimpleResource
-import com.socrata.http.server.{HttpService, HttpRequest}
+import com.socrata.http.server.{HttpRequest, HttpService}
 import org.slf4j.LoggerFactory
 
 class VersionService

--- a/src/main/scala/com/socrata/cetera/types/Datatypes.scala
+++ b/src/main/scala/com/socrata/cetera/types/Datatypes.scala
@@ -4,32 +4,37 @@ object Datatypes {
   val materialized: Seq[Materialized] = Seq(TypeCalendars, TypeCharts,
     TypeDatalenses, TypeDatasets, TypeFiles, TypeFilters, TypeForms,
     TypeMaps, TypeHrefs, TypePulses, TypeStories)
-  val renamed: Seq[DatatypeSimple] = Seq(TypeLinks)
-  val viewSpecific: Seq[DatatypeSimple] = Seq(TypeDatalensCharts, TypeDatalensMaps, TypeTabularMaps)
+  val renamed: Seq[Datatype] = Seq(TypeLinks)
+  val viewSpecific: Seq[Datatype] = Seq(TypeDatalensCharts, TypeDatalensMaps, TypeTabularMaps)
 
-  val all: Seq[DatatypeSimple] = viewSpecific ++ renamed ++ materialized
+  val all: Seq[Datatype] = viewSpecific ++ renamed ++ materialized
 }
 
-trait DatatypeSimple {
-  val plural: String
+trait Datatype {
+  def plural: String
+  def singular: String
+  def names: Seq[String]
+}
+
+object Datatype {
+  def apply(s: String): Option[Datatype] = {
+    Datatypes.all.find(d => d.plural == s || d.singular == s).headOption
+  }
+  def apply(so: Option[String]): Option[Datatype] = {
+    so.flatMap(Datatype(_))
+  }
+}
+
+trait DatatypeSimple extends Datatype {
   lazy val singular: String = plural.dropRight(1)
   lazy val names: Seq[String] = Seq(singular)
 }
 
-object DatatypeSimple {
-  def apply(s: String): Option[DatatypeSimple] = {
-    Datatypes.all.find(d => d.plural == s || d.singular == s).headOption
-  }
-  def apply(so: Option[String]): Option[DatatypeSimple] = {
-    so.flatMap(DatatypeSimple(_))
-  }
+trait DatatypeRename extends Datatype {
+  lazy val singular: String = plural.dropRight(1)
 }
 
-trait DatatypeRename extends DatatypeSimple {
-  override lazy val names: Seq[String] = ???
-}
-
-trait Materialized extends DatatypeSimple
+trait Materialized extends Datatype
 
 case object TypeCalendars extends DatatypeSimple with Materialized {
   val plural = "calendars"

--- a/src/main/scala/com/socrata/cetera/util/ParamConverter.scala
+++ b/src/main/scala/com/socrata/cetera/util/ParamConverter.scala
@@ -1,33 +1,32 @@
 package com.socrata.cetera.util
 
+import scala.util.control.NonFatal
+
 trait ParamConverter[T] {
   def convertFrom(s: String): Either[ParamConversionFailure, T]
+
+  private def convertFrom(s: String, f: (String => T)): Either[ParamConversionFailure, T] =
+    try {
+      Right(f(s))
+    } catch {
+      case NonFatal(_) => Left(InvalidValue(s))
+    }
 }
 
 object ParamConverter {
   implicit object IntParam extends ParamConverter[Int] {
-    override def convertFrom(s: String): Either[ParamConversionFailure, Int] = {
-      try { Right(s.toInt) }
-      catch { case e: Exception => Left(InvalidValue(s)) }
-    }
+    override def convertFrom(s: String): Either[ParamConversionFailure, Int] = convertFrom(s, _.toInt)
   }
 
   implicit object FloatParam extends ParamConverter[Float] {
-    override def convertFrom(s: String): Either[ParamConversionFailure, Float] = {
-      try { Right(s.toFloat) }
-      catch { case e: Exception => Left(InvalidValue(s)) }
-    }
+    override def convertFrom(s: String): Either[ParamConversionFailure, Float] = convertFrom(s, _.toFloat)
   }
 
   def filtered[A: ParamConverter, B](f: A => Option[B]): ParamConverter[B] = {
     new ParamConverter[B] {
       def convertFrom(s: String): Either[ParamConversionFailure, B] = {
         implicitly[ParamConverter[A]].convertFrom(s) match {
-          case Right(a) =>
-            f(a) match {
-              case Some(b) => Right(b)
-              case None => Left(InvalidValue(s))
-            }
+          case Right(a) => f(a).map(Right(_)).getOrElse(Left(InvalidValue(s)))
           case Left(e) => Left(e)
         }
       }

--- a/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
+++ b/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
@@ -13,7 +13,7 @@ case class ValidatedQueryParameters(
   tags: Option[Set[String]],
   only: Option[Seq[String]],
   fieldBoosts: Map[CeteraFieldType with Boostable, Float],
-  datatypeBoosts: Map[DatatypeSimple, Float],
+  datatypeBoosts: Map[Datatype, Float],
   minShouldMatch: Option[String],
   slop: Option[Int],
   showScore: Boolean,
@@ -62,7 +62,7 @@ object QueryParametersParser {
   // This can stay case-sensitive because it is so specific
   def restrictParamFilterType(only: Option[String]): Either[OnlyError, Option[Seq[String]]] =
     only.map { s =>
-      DatatypeSimple(s) match {
+      Datatype(s) match {
         case None => Left(OnlyError(s"'only' must be one of $allowedTypes; got $s"))
         case Some(d) => Right(Some(d.names))
       }
@@ -167,9 +167,9 @@ object Params {
       None
     }
 
-  def datatypeBoostParam(param: String): Option[DatatypeSimple] =
+  def datatypeBoostParam(param: String): Option[Datatype] =
     datatypeBoostParams.find(_ == param).flatMap(boostParam =>
-      DatatypeSimple(typeNameFromBoostParam(boostParam.toLowerCase)))
+      Datatype(typeNameFromBoostParam(boostParam.toLowerCase)))
 
   // field boosting parameters
   val boostColumns = "boostColumns"

--- a/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
+++ b/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
@@ -113,7 +113,7 @@ object QueryParametersParser {
           o,
           fieldBoosts,
           datatypeBoosts,
-          queryParameters.first(Params.minMatch).flatMap { case p: String => MinShouldMatch.fromParam(query, p) },
+          queryParameters.first(Params.minMatch).flatMap { p => MinShouldMatch.fromParam(query, p) },
           queryParameters.typedFirst[Int](Params.slop).map(validated), // Check for slop
           queryParameters.contains(Params.showScore), // just a flag
           validated(queryParameters.typedFirstOrElse(Params.scanOffset, NonNegativeInt(defaultPageOffset))).value,

--- a/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
+++ b/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
@@ -80,9 +80,9 @@ object QueryParametersParser {
     )
 
     val fieldBoosts = {
-      val boostTitle = queryParameters.getTypedFirst[NonNegativeFloat](Params.boostTitle).map(validated(_).value)
-      val boostDesc = queryParameters.getTypedFirst[NonNegativeFloat](Params.boostDescription).map(validated(_).value)
-      val boostColumns = queryParameters.getTypedFirst[NonNegativeFloat](Params.boostColumns).map(validated(_).value)
+      val boostTitle = queryParameters.typedFirst[NonNegativeFloat](Params.boostTitle).map(validated(_).value)
+      val boostDesc = queryParameters.typedFirst[NonNegativeFloat](Params.boostDescription).map(validated(_).value)
+      val boostColumns = queryParameters.typedFirst[NonNegativeFloat](Params.boostColumns).map(validated(_).value)
 
       Map(
         TitleFieldType -> boostTitle,
@@ -97,27 +97,27 @@ object QueryParametersParser {
 
     val datatypeBoosts = queryParameters.flatMap {
       case (k, _) => Params.datatypeBoostParam(k).flatMap(datatype =>
-        queryParameters.getTypedFirst[NonNegativeFloat](k).map(boost =>
+        queryParameters.typedFirst[NonNegativeFloat](k).map(boost =>
           (datatype, validated(boost).value)))
     }
 
-    restrictParamFilterType(queryParameters.getFirst(Params.filterType)) match {
+    restrictParamFilterType(queryParameters.first(Params.filterType)) match {
       case Right(o) =>
         Right(ValidatedQueryParameters(
           query,
-          queryParameters.getFirst(Params.filterDomains).map(_.toLowerCase.split(filterDelimiter).toSet),
+          queryParameters.first(Params.filterDomains).map(_.toLowerCase.split(filterDelimiter).toSet),
           Option(queryStringDomainMetadata(queryParameters)),
-          queryParameters.getFirst(Params.context).map(_.toLowerCase),
+          queryParameters.first(Params.context).map(_.toLowerCase),
           queryParameters.get(Params.filterCategories).map(_.toSet),
           queryParameters.get(Params.filterTags).map(_.map(tag => tag.toLowerCase).toSet),
           o,
           fieldBoosts,
           datatypeBoosts,
-          queryParameters.getFirst(Params.minMatch).flatMap { case p: String => MinShouldMatch.fromParam(query, p) },
-          queryParameters.getTypedFirst[Int](Params.slop).map(validated), // Check for slop
+          queryParameters.first(Params.minMatch).flatMap { case p: String => MinShouldMatch.fromParam(query, p) },
+          queryParameters.typedFirst[Int](Params.slop).map(validated), // Check for slop
           queryParameters.contains(Params.showScore), // just a flag
-          validated(queryParameters.getTypedFirstOrElse(Params.scanOffset, NonNegativeInt(defaultPageOffset))).value,
-          validated(queryParameters.getTypedFirstOrElse(Params.scanLength, NonNegativeInt(defaultPageLength))).value
+          validated(queryParameters.typedFirstOrElse(Params.scanOffset, NonNegativeInt(defaultPageOffset))).value,
+          validated(queryParameters.typedFirstOrElse(Params.scanLength, NonNegativeInt(defaultPageLength))).value
         ))
       case Left(e) => Left(Seq(e))
     }

--- a/src/main/scala/com/socrata/cetera/util/package.scala
+++ b/src/main/scala/com/socrata/cetera/util/package.scala
@@ -11,22 +11,22 @@ package object util {
   }
 
   implicit class TypedQueryParams(queryParameters: MultiQueryParams) {
-    def getFirst(name: String): Option[String] = {
+    def first(name: String): Option[String] = {
       queryParameters.get(name).flatMap(_.headOption)
     }
 
-    def getTypedSeq[T: ParamConverter](name: String): Option[Seq[Either[ParamConversionFailure, T]]] = {
+    def typedSeq[T: ParamConverter](name: String): Option[Seq[Either[ParamConversionFailure, T]]] = {
       queryParameters.get(name).map {
         _.map(implicitly[ParamConverter[T]].convertFrom)
       }
     }
 
-    def getTypedFirst[T: ParamConverter](name: String): Option[Either[ParamConversionFailure, T]] = {
-      queryParameters.getTypedSeq[T](name).flatMap(_.headOption)
+    def typedFirst[T: ParamConverter](name: String): Option[Either[ParamConversionFailure, T]] = {
+      queryParameters.typedSeq[T](name).flatMap(_.headOption)
     }
 
-    def getTypedFirstOrElse[T: ParamConverter](name: String, default: T): Either[ParamConversionFailure, T] = {
-      getTypedFirst[T](name).getOrElse(Right(default))
+    def typedFirstOrElse[T: ParamConverter](name: String, default: T): Either[ParamConversionFailure, T] = {
+      typedFirst[T](name).getOrElse(Right(default))
     }
   }
 }

--- a/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
@@ -24,14 +24,14 @@ class DomainClientSpec extends WordSpec with ShouldMatchers  with TestESData wit
         siteTitle = Some("Temporary URI"),
         moderationEnabled = false,
         routingApprovalEnabled = true)
-      val actualDomain = domainClient.getDomain("petercetera.net")
+      val actualDomain = domainClient.find("petercetera.net")
 
       actualDomain.get should be(expectedDomain)
     }
 
     "return None if the domain does not exist" in {
       val expectedDomain = None
-      val actualDomain = domainClient.getDomain("hellcat.com")
+      val actualDomain = domainClient.find("hellcat.com")
 
       actualDomain should be(expectedDomain)
     }

--- a/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
@@ -3,11 +3,11 @@ package com.socrata.cetera.services
 import com.rojoma.json.v3.ast.{JNumber, JString}
 import com.rojoma.json.v3.codec.DecodeError
 import com.rojoma.json.v3.interpolation._
-import com.socrata.cetera.types.Count
-import com.socrata.cetera.util.SearchResults
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
 
-import com.socrata.cetera.search.{ElasticSearchClient, DomainClient, TestESClient, DocumentClient}
+import com.socrata.cetera.search.{DocumentClient, DomainClient, ElasticSearchClient, TestESClient}
+import com.socrata.cetera.types.Count
+import com.socrata.cetera.util.SearchResults
 
 class CountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAll {
   val client: ElasticSearchClient = new TestESClient("CountService")

--- a/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
@@ -1,8 +1,7 @@
 package com.socrata.cetera.services
 
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
-
 import com.rojoma.json.v3.ast.{JNumber, JString}
+import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
 
 import com.socrata.cetera.search._
 import com.socrata.cetera.types._

--- a/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
@@ -9,7 +9,7 @@ import com.socrata.cetera.util.Params
 
 class DatatypeBoostSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
   val boostedDatatype = TypeCharts
-  val datatypeBoosts =  Map[DatatypeSimple, Float](boostedDatatype -> 10F)
+  val datatypeBoosts =  Map[Datatype, Float](boostedDatatype -> 10F)
 
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
   val documentClient: DocumentClient = new DocumentClient(client, datatypeBoosts, None, None, Set.empty)

--- a/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -139,7 +139,7 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
       Map(dt -> "href"),
       Map(dt -> "story", xp -> "/stories/s/", xs -> "/stories/s/")
     ).foreach { t =>
-      val urls = SearchService.links(cname, DatatypeSimple(t.get(dt)), t.get(vt), id, category, name)
+      val urls = SearchService.links(cname, Datatype(t.get(dt)), t.get(vt), id, category, name)
       urls.getOrElse("permalink", fail()).string should include(t.getOrElse(xp, xpDefault))
       urls.getOrElse("link", fail()).string should include(t.getOrElse(xs, xsDefault))
     }

--- a/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -4,9 +4,6 @@ import scala.collection.JavaConverters._
 
 import com.rojoma.json.v3.ast.{JString, JValue}
 import com.rojoma.json.v3.interpolation._
-import com.socrata.cetera._
-import com.socrata.cetera.search._
-import com.socrata.cetera.types._
 import org.elasticsearch.action.search._
 import org.elasticsearch.common.bytes.BytesArray
 import org.elasticsearch.common.text.StringText
@@ -16,6 +13,10 @@ import org.elasticsearch.search.internal._
 import org.elasticsearch.search.suggest.Suggest
 import org.elasticsearch.search.{SearchHitField, SearchShardTarget}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+
+import com.socrata.cetera._
+import com.socrata.cetera.search._
+import com.socrata.cetera.types._
 
 class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAll {
   val client: ElasticSearchClient = new TestESClient("SearchService")

--- a/src/test/scala/com/socrata/cetera/util/ElasticsearchErrorSpec.scala
+++ b/src/test/scala/com/socrata/cetera/util/ElasticsearchErrorSpec.scala
@@ -1,6 +1,6 @@
 package com.socrata.cetera.util
 
-import org.scalatest.{Matchers, FunSuiteLike}
+import org.scalatest.{FunSuiteLike, Matchers}
 
 class ElasticsearchErrorSpec extends FunSuiteLike with Matchers {
   test("parse this one error") {


### PR DESCRIPTION
avoid catching fatal exceptions
specify default case
avoid naming methods `getX`
imports should be sorted alphabetically, after our conventional java, scala, external, internal ordering.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata/cetera/105)
<!-- Reviewable:end -->
