### PR TITLE
Jason/clean up document client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ scalacOptions ++= Seq("-Yinline-warnings")
 
 // This forks a new JVM because our ES tests leak threads
 fork in Test := true
-testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDS")
 
 // Make sure the "configs" dir is on the runtime classpaths so application.conf can be found.
 fullClasspath in Runtime <+= baseDirectory map { d => Attributed.blank(d / "configs") }

--- a/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.{ExecutorService, Executors}
 
 import com.rojoma.simplearm.v2._
 import com.socrata.http.client.InetLivenessChecker
-import com.socrata.http.server._
+import com.socrata.http.server.SocrataServerJetty
 import com.socrata.thirdparty.typesafeconfig.Propertizer
 import com.typesafe.config.ConfigFactory
 import org.apache.log4j.PropertyConfigurator
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory
 import com.socrata.cetera.config.CeteraConfig
 import com.socrata.cetera.handlers.Router
 import com.socrata.cetera.search.{DocumentClient, DomainClient, ElasticSearchClient}
-import com.socrata.cetera.services._
+import com.socrata.cetera.services.{CountService, FacetService, SearchService, VersionService}
 import com.socrata.cetera.types.ScriptScoreFunction
 
 // $COVERAGE-OFF$ jetty wiring

--- a/src/main/scala/com/socrata/cetera/handlers/Router.scala
+++ b/src/main/scala/com/socrata/cetera/handlers/Router.scala
@@ -1,13 +1,13 @@
 package com.socrata.cetera.handlers
 
 import com.socrata.http.server.implicits._
-import com.socrata.http.server.responses._
-import com.socrata.http.server.routing.SimpleRouteContext._
+import com.socrata.http.server.responses.NotFound
+import com.socrata.http.server.routing.SimpleRouteContext.{Route, Routes}
 import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 
-import com.socrata.cetera._
+import com.socrata.cetera.HeaderAclAllowOriginAll
 import com.socrata.cetera.types._
-import com.socrata.cetera.util.JsonResponses._
+import com.socrata.cetera.util.JsonResponses.jsonError
 
 // $COVERAGE-OFF$ jetty wiring
 // Now the router knows about our ES field names

--- a/src/main/scala/com/socrata/cetera/handlers/Router.scala
+++ b/src/main/scala/com/socrata/cetera/handlers/Router.scala
@@ -41,6 +41,7 @@ class Router(
     Route("/catalog/tags", countResource(TagsFieldType)),
     Route("/catalog/v1/tags", countResource(TagsFieldType)),
 
+    // document counts for queries grouped by domain_category
     Route("/catalog/domain_categories", countResource(DomainCategoryFieldType)),
     Route("/catalog/v1/domain_categories", countResource(DomainCategoryFieldType))
   )

--- a/src/main/scala/com/socrata/cetera/search/Aggregations.scala
+++ b/src/main/scala/com/socrata/cetera/search/Aggregations.scala
@@ -1,29 +1,29 @@
 package com.socrata.cetera.search
 
-import org.elasticsearch.search.aggregations.AggregationBuilders
+import org.elasticsearch.search.aggregations.{AbstractAggregationBuilder, AggregationBuilders}
 import org.elasticsearch.search.aggregations.bucket.terms.Terms
 
-import com.socrata.cetera.types.{CategoriesFieldType, DomainCategoryFieldType, DomainFieldType, TagsFieldType}
+import com.socrata.cetera.types._
 
 object Aggregations {
   // The 'terms' and 'nested' fields need to jive with
   // ../services/CountService.scala
 
-  val aggDomain =
+  val domains =
     AggregationBuilders
       .terms("domains")
       .field(DomainFieldType.rawFieldName)
       .order(Terms.Order.count(false)) // count desc
       .size(0) // no docs, aggs only
 
-  val aggDomainCategory =
+  val domainCategories =
     AggregationBuilders
       .terms("domain_categories")
       .field(DomainCategoryFieldType.rawFieldName)
       .order(Terms.Order.count(false)) // count desc
       .size(0) // no docs, aggs only
 
-  val aggCategories =
+  val categories =
     AggregationBuilders
       .nested("annotations")
       .path(CategoriesFieldType.fieldName)
@@ -34,7 +34,7 @@ object Aggregations {
           .size(0)
       )
 
-  val aggTags =
+  val tags =
     AggregationBuilders
       .nested("annotations")
       .path(TagsFieldType.fieldName)
@@ -44,4 +44,13 @@ object Aggregations {
           .field(TagsFieldType.Name.rawFieldName)
           .size(0)
       )
+
+  def chooseAggregation(field: CeteraFieldType with Countable with Rawable) : AbstractAggregationBuilder =
+    field match {
+      case DomainFieldType => Aggregations.domains
+      case DomainCategoryFieldType => Aggregations.domainCategories
+
+      case CategoriesFieldType => Aggregations.categories
+      case TagsFieldType => Aggregations.tags
+    }
 }

--- a/src/main/scala/com/socrata/cetera/search/Aggregations.scala
+++ b/src/main/scala/com/socrata/cetera/search/Aggregations.scala
@@ -3,7 +3,7 @@ package com.socrata.cetera.search
 import org.elasticsearch.search.aggregations.AggregationBuilders
 import org.elasticsearch.search.aggregations.bucket.terms.Terms
 
-import com.socrata.cetera.types._
+import com.socrata.cetera.types.{CategoriesFieldType, DomainCategoryFieldType, DomainFieldType, TagsFieldType}
 
 object Aggregations {
   // The 'terms' and 'nested' fields need to jive with
@@ -44,5 +44,4 @@ object Aggregations {
           .field(TagsFieldType.Name.rawFieldName)
           .size(0)
       )
-
 }

--- a/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -326,11 +326,8 @@ class DocumentClient(
           .field(DomainMetadataFieldType.Value.rawFieldName)
           .size(size)))
 
-    // TODO: fix this awkward construction and resolve how we feel about nulls
-    val filter: FilterBuilder = Option(cname) match {
-      case Some(s) if s.nonEmpty => Filters.domainFilter(Some(Set(cname))).get
-      case _ => FilterBuilders.matchAllFilter()
-    }
+    val filter = Filters.domainFilter(cname)
+      .getOrElse(FilterBuilders.matchAllFilter())
 
     val filteredAggs = AggregationBuilders
       .filter("domain_filter")

--- a/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -3,7 +3,7 @@ package com.socrata.cetera.search
 import org.elasticsearch.action.search.SearchRequestBuilder
 import org.elasticsearch.index.query._
 import org.elasticsearch.search.aggregations.AggregationBuilders
-import org.elasticsearch.search.sort.{SortBuilders, SortOrder}
+import org.elasticsearch.search.sort.{FieldSortBuilder, SortBuilder, SortBuilders, SortOrder}
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
@@ -14,26 +14,34 @@ import com.socrata.cetera.types._
 
 object DocumentClient {
   def apply(
-    esClient: ElasticSearchClient,
-    defaultTypeBoosts: Map[String, Float],
-    defaultTitleBoost: Option[Float],
-    defaultMinShouldMatch: Option[String],
-    scriptScoreFunctions: Set[ScriptScoreFunction]
-    ): DocumentClient = {
+      esClient: ElasticSearchClient,
+      defaultTypeBoosts: Map[String, Float],
+      defaultTitleBoost: Option[Float],
+      defaultMinShouldMatch: Option[String],
+      scriptScoreFunctions: Set[ScriptScoreFunction])
+    : DocumentClient = {
+
     val datatypeBoosts = defaultTypeBoosts.flatMap { case (k, v) =>
       Datatype(k).map(datatype => (datatype, v))
     }
-    new DocumentClient(esClient, datatypeBoosts, defaultTitleBoost, defaultMinShouldMatch, scriptScoreFunctions)
+
+    new DocumentClient(
+      esClient,
+      datatypeBoosts,
+      defaultTitleBoost,
+      defaultMinShouldMatch,
+      scriptScoreFunctions
+    )
   }
 }
 
 class DocumentClient(
-  esClient: ElasticSearchClient,
-  defaultTypeBoosts: Map[Datatype, Float],
-  defaultTitleBoost: Option[Float],
-  defaultMinShouldMatch: Option[String],
-  scriptScoreFunctions: Set[ScriptScoreFunction]
-  ) {
+    esClient: ElasticSearchClient,
+    defaultTypeBoosts: Map[Datatype, Float],
+    defaultTitleBoost: Option[Float],
+    defaultMinShouldMatch: Option[String],
+    scriptScoreFunctions: Set[ScriptScoreFunction]) {
+
   val logger = LoggerFactory.getLogger(getClass)
 
   private def logESRequest(search: SearchRequestBuilder): Unit =
@@ -56,61 +64,66 @@ class DocumentClient(
   //
   //   https://www.elastic.co/guide/en/elasticsearch/guide/current/proximity-relevance.html
   def generateQuery(
-    searchQuery: QueryType,
-    fieldBoosts: Map[CeteraFieldType with Boostable, Float],
-    typeBoosts: Map[Datatype, Float],
-    minShouldMatch: Option[String],
-    slop: Option[Int]
-  ): BaseQueryBuilder = {
+      searchQuery: QueryType,
+      fieldBoosts: Map[CeteraFieldType with Boostable, Float],
+      typeBoosts: Map[Datatype, Float],
+      minShouldMatch: Option[String],
+      slop: Option[Int])
+    : BaseQueryBuilder = {
+
     searchQuery match {
-      case NoQuery => QueryBuilders.matchAllQuery
+      case NoQuery =>
+        QueryBuilders.matchAllQuery
 
       case SimpleQuery(sq) =>
         val matchTerms = multiMatch(sq, MultiMatchQueryBuilder.Type.CROSS_FIELDS)
 
         // Side effects!
         fieldBoosts.foreach { case (field, weight) => matchTerms.field(field.fieldName, weight) }
-
         minShouldMatch.foreach(addMinMatchConstraint(matchTerms, _))
 
         val matchPhrase = multiMatch(sq, MultiMatchQueryBuilder.Type.PHRASE)
 
-        // Note, if no slop is specified, we do not set a default
+        // NOTE: if no slop is specified, we do not set a default
         slop.foreach(addSlopParam(matchPhrase, _))
 
         // Combines the two queries above into a single Boolean query
-        val q = QueryBuilders.boolQuery().must(matchTerms).should(matchPhrase)
+        val query = QueryBuilders.boolQuery().must(matchTerms).should(matchPhrase)
 
         // If we have typeBoosts, add them as should match clause
         if (typeBoosts.nonEmpty) {
-          q.should(boostTypes(typeBoosts))
+          query.should(boostTypes(typeBoosts))
         } else {
-          q
+          query
         }
 
       case AdvancedQuery(aq) =>
-        val query = QueryBuilders.queryStringQuery(aq).
-          field("fts_analyzed").
-          field("fts_raw").
-          field("domain_cname").
-          autoGeneratePhraseQueries(true)
+        val query = QueryBuilders
+          .queryStringQuery(aq)
+          .field("fts_analyzed")
+          .field("fts_raw")
+          .field("domain_cname")
+          .autoGeneratePhraseQueries(true)
 
         // Side effects!
-        fieldBoosts.foreach {
-          case (field, weight) => query.field(field.fieldName, weight)
+        fieldBoosts.foreach { case (field, weight) =>
+          query.field(field.fieldName, weight)
         }
 
         query
     }
   }
 
-  private def buildFilteredQuery(datatypes: Option[Seq[String]],
-                                 domains: Option[Set[String]],
-                                 searchContext: Option[Domain],
-                                 categories: Option[Set[String]],
-                                 tags: Option[Set[String]],
-                                 domainMetadata: Option[Set[(String, String)]],
-                                 q: BaseQueryBuilder): BaseQueryBuilder = {
+  private def buildFilteredQuery(
+      datatypes: Option[Seq[String]],
+      domains: Option[Set[String]],
+      searchContext: Option[Domain],
+      categories: Option[Set[String]],
+      tags: Option[Set[String]],
+      domainMetadata: Option[Set[(String, String)]],
+      query: BaseQueryBuilder)
+    : BaseQueryBuilder = {
+
     // If there is no search context, use the ODN categories and tags and prohibit domain metadata
     // otherwise use the custom domain categories, tags, metadata
     val odnFilters = List.concat(
@@ -118,12 +131,15 @@ class DocumentClient(
       categoriesFilter(categories),
       tagsFilter(tags)
     )
+
     val domainFilters = List.concat(
       domainCategoriesFilter(categories),
       domainTagsFilter(tags),
       domainMetadataFilter(domainMetadata)
     )
+
     val moderated = searchContext.exists(_.moderationEnabled)
+
     val filters = List.concat(
       datatypeFilter(datatypes),
       domainFilter(domains),
@@ -131,95 +147,148 @@ class DocumentClient(
       routingApprovalFilter(searchContext),
       if (searchContext.isDefined) domainFilters else odnFilters
     )
+
     if (filters.nonEmpty) {
-      QueryBuilders.filteredQuery(q, FilterBuilders.andFilter(filters.toSeq: _*))
+      QueryBuilders.filteredQuery(
+        query,
+        FilterBuilders.andFilter(filters.toSeq: _*)
+      )
     } else {
-      q
+      query
     }
   }
 
   // Assumes validation has already been done
   def buildBaseRequest( // scalastyle:ignore parameter.number
-    searchQuery: QueryType,
-    domains: Option[Set[String]],
-    searchContext: Option[Domain],
-    categories: Option[Set[String]],
-    tags: Option[Set[String]],
-    domainMetadata: Option[Set[(String, String)]],
-    only: Option[Seq[String]],
-    fieldBoosts: Map[CeteraFieldType with Boostable, Float],
-    datatypeBoosts: Map[Datatype, Float],
-    minShouldMatch: Option[String],
-    slop: Option[Int]
-  ): SearchRequestBuilder = {
+      searchQuery: QueryType,
+      domains: Option[Set[String]],
+      searchContext: Option[Domain],
+      categories: Option[Set[String]],
+      tags: Option[Set[String]],
+      domainMetadata: Option[Set[(String, String)]],
+      only: Option[Seq[String]],
+      fieldBoosts: Map[CeteraFieldType with Boostable, Float],
+      datatypeBoosts: Map[Datatype, Float],
+      minShouldMatch: Option[String],
+      slop: Option[Int])
+    : SearchRequestBuilder = {
+
     val matchQuery: BaseQueryBuilder = generateQuery(
       searchQuery,
-      // Look for default title boost; if a title boost is specified as a query parameter, it
-      // will override the default
+
+      // Look for default title boost; if a title boost is specified as a query
+      // parameter, it will override the default
       defaultTitleBoost.map(boost => Map(TitleFieldType -> boost) ++ fieldBoosts).getOrElse(fieldBoosts),
       defaultTypeBoosts ++ datatypeBoosts,
-      // If we're doing a within-domain catalog search then we want to optimize for precision
-      // so by default, we use the defaultMinShouldMatch setting; but we'll always honor the parameter
-      // value passed in with the query
+
+      // If we're doing a within-domain catalog search then we want to optimize
+      // for precision so by default, we use the defaultMinShouldMatch setting;
+      // but we'll always honor the parameter value passed in with the query
       minShouldMatch.orElse(if (searchContext.isDefined) defaultMinShouldMatch else None),
       slop
     )
 
-    val q = if (scriptScoreFunctions.nonEmpty) {
-      val query = QueryBuilders.functionScoreQuery(matchQuery)
-      addFunctionScores(scriptScoreFunctions, query)
-    } else { matchQuery }
+    val query = if (scriptScoreFunctions.nonEmpty) {
+      addFunctionScores(
+        scriptScoreFunctions,
+        QueryBuilders.functionScoreQuery(matchQuery)
+      )
+    } else {
+      matchQuery
+    }
 
-    val query: BaseQueryBuilder = buildFilteredQuery(only, domains, searchContext, categories, tags, domainMetadata, q)
+    val filteredQuery = buildFilteredQuery(
+      only,
+      domains,
+      searchContext,
+      categories,
+      tags,
+      domainMetadata,
+      query
+    )
 
     // Imperative builder --> order is important
-    val search = esClient.client.prepareSearch(Indices: _*)
-      .setQuery(query)
+    val preparedSearch = esClient.client
+      .prepareSearch(Indices: _*)
+      .setQuery(filteredQuery)
       .setTypes(esDocumentType)
-    logESRequest(search)
-    search
+
+    logESRequest(preparedSearch)
+    preparedSearch
   }
 
-  // First pass logic is very simple. advanced query >> query >> categories >> tags >> default
-  def buildSearchRequest( // scalastyle:ignore parameter.number
-    searchQuery: QueryType,
-    domains: Option[Set[String]],
-    domainMetadata: Option[Set[(String, String)]],
-    searchContext: Option[Domain],
-    categories: Option[Set[String]],
-    tags: Option[Set[String]],
-    only: Option[Seq[String]],
-    fieldBoosts: Map[CeteraFieldType with Boostable, Float],
-    datatypeBoosts: Map[Datatype, Float],
-    minShouldMatch: Option[String],
-    slop: Option[Int],
-    offset: Int,
-    limit: Int,
-    advancedQuery: Option[String] = None
-  ): SearchRequestBuilder = {
-    val sort = (searchQuery, categories, tags) match {
+  def buildAverageScoreSort(
+      fieldName: String,
+      rawFieldName: String,
+      classifications: Set[String])
+    : FieldSortBuilder = {
+
+    SortBuilders
+      .fieldSort(fieldName)
+      .order(SortOrder.DESC)
+      .sortMode("avg")
+      .setNestedFilter(
+        FilterBuilders.termsFilter(
+          rawFieldName,
+          classifications.toSeq: _*
+        )
+      )
+  }
+
+  // TODO: Possibly chooseSort is a better name
+  // First pass logic is very simple. query >> categories >> tags >> default
+  def buildSort(
+      searchQuery: QueryType,
+      searchContext: Option[Domain],
+      categories: Option[Set[String]],
+      tags: Option[Set[String]])
+    : SortBuilder = {
+
+    (searchQuery, categories, tags) match {
       // Query
       case (AdvancedQuery(_) | SimpleQuery(_), _, _) => sortScoreDesc
 
       // ODN Categories
+      // Q: What happens when we search according to domain_categories? It's not clear
       case (_, Some(cats), _) if searchContext.isEmpty =>
-        SortBuilders
-          .fieldSort(CategoriesFieldType.Score.fieldName)
-          .order(SortOrder.DESC)
-          .sortMode("avg")
-          .setNestedFilter(FilterBuilders.termsFilter(CategoriesFieldType.Name.rawFieldName, cats.toSeq: _*))
+        buildAverageScoreSort(
+          CategoriesFieldType.Score.fieldName,
+          CategoriesFieldType.Name.rawFieldName,
+          cats
+        )
 
       // ODN Tags
       case (_, _, Some(ts)) if searchContext.isEmpty =>
-        SortBuilders
-          .fieldSort(TagsFieldType.Score.fieldName)
-          .order(SortOrder.DESC)
-          .sortMode("avg")
-          .setNestedFilter(FilterBuilders.termsFilter(TagsFieldType.Name.rawFieldName, ts.toSeq: _*))
+        buildAverageScoreSort(
+          TagsFieldType.Score.fieldName,
+          TagsFieldType.Name.rawFieldName,
+          ts
+        )
 
-      // Default
-      case (_, _, _) => sortFieldDesc(PageViewsTotalFieldType.fieldName)
+      // Default (No query, categories, or tags)
+      case (_, _, _) =>
+        sortFieldDesc(PageViewsTotalFieldType.fieldName)
     }
+  }
+
+  def buildSearchRequest( // scalastyle:ignore parameter.number
+      searchQuery: QueryType,
+      domains: Option[Set[String]],
+      domainMetadata: Option[Set[(String, String)]],
+      searchContext: Option[Domain],
+      categories: Option[Set[String]],
+      tags: Option[Set[String]],
+      only: Option[Seq[String]],
+      fieldBoosts: Map[CeteraFieldType with Boostable, Float],
+      datatypeBoosts: Map[Datatype, Float],
+      minShouldMatch: Option[String],
+      slop: Option[Int],
+      offset: Int,
+      limit: Int,
+      advancedQuery: Option[String] = None)
+    : SearchRequestBuilder = {
+
+    val sort = buildSort(searchQuery, searchContext, categories, tags)
 
     buildBaseRequest(searchQuery, domains, searchContext, categories, tags, domainMetadata,
                      only, fieldBoosts, datatypeBoosts, minShouldMatch, slop)
@@ -229,14 +298,15 @@ class DocumentClient(
   }
 
   def buildCountRequest(
-    field: CeteraFieldType with Countable with Rawable,
-    searchQuery: QueryType,
-    domains: Option[Set[String]],
-    searchContext: Option[Domain],
-    categories: Option[Set[String]],
-    tags: Option[Set[String]],
-    only: Option[Seq[String]]
-  ): SearchRequestBuilder = {
+      field: CeteraFieldType with Countable with Rawable,
+      searchQuery: QueryType,
+      domains: Option[Set[String]],
+      searchContext: Option[Domain],
+      categories: Option[Set[String]],
+      tags: Option[Set[String]],
+      only: Option[Seq[String]])
+    : SearchRequestBuilder = {
+
     val aggregation = field match {
       case DomainFieldType => aggDomain
       case CategoriesFieldType => aggCategories
@@ -244,8 +314,8 @@ class DocumentClient(
       case DomainCategoryFieldType => aggDomainCategory
     }
 
-    buildBaseRequest(searchQuery, domains, searchContext, categories, tags, None, only,
-                     Map.empty, Map.empty, None, None)
+    buildBaseRequest(searchQuery, domains, searchContext, categories, tags,
+                     None, only, Map.empty, Map.empty, None, None)
       .addAggregation(aggregation)
       .setSearchType("count")
   }
@@ -253,40 +323,52 @@ class DocumentClient(
   def buildFacetRequest(cname: String): SearchRequestBuilder = {
     val size = 0 // no docs, aggs only
 
-    val datatypeAgg = AggregationBuilders.terms("datatypes")
+    val datatypeAgg = AggregationBuilders
+      .terms("datatypes")
       .field(DatatypeFieldType.fieldName)
       .size(size)
-    val categoryAgg = AggregationBuilders.terms("categories")
+
+
+    val categoryAgg = AggregationBuilders
+      .terms("categories")
       .field(DomainCategoryFieldType.rawFieldName)
       .size(size)
-    val tagAgg = AggregationBuilders.terms("tags")
+
+    val tagAgg = AggregationBuilders
+      .terms("tags")
       .field(DomainTagsFieldType.rawFieldName)
       .size(size)
-    val metadataAgg = AggregationBuilders.nested("metadata")
+
+    val metadataAgg = AggregationBuilders
+      .nested("metadata")
       .path(DomainMetadataFieldType.fieldName)
       .subAggregation(AggregationBuilders.terms("keys")
         .field(DomainMetadataFieldType.Key.rawFieldName)
         .size(size)
         .subAggregation(AggregationBuilders.terms("values")
           .field(DomainMetadataFieldType.Value.rawFieldName)
-          .size(size)
-      ))
+          .size(size)))
 
     val filter = Option(cname) match {
       case Some(s) if s.nonEmpty => domainFilter(Some(Set(cname))).getOrElse(throw new NoSuchElementException)
       case _ => FilterBuilders.matchAllFilter()
     }
-    val filteredAggs = AggregationBuilders.filter("domain_filter")
+
+    val filteredAggs = AggregationBuilders
+      .filter("domain_filter")
       .filter(filter)
       .subAggregation(datatypeAgg)
       .subAggregation(categoryAgg)
       .subAggregation(tagAgg)
       .subAggregation(metadataAgg)
 
-    val search = esClient.client.prepareSearch(Indices: _*)
+    val preparedSearch = esClient.client
+      .prepareSearch(Indices: _*)
       .addAggregation(filteredAggs)
       .setSize(size)
-    logESRequest(search)
-    search
+
+    logESRequest(preparedSearch)
+    preparedSearch
   }
 }
+

--- a/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -3,7 +3,7 @@ package com.socrata.cetera.search
 import com.rojoma.json.v3.codec.JsonDecode
 import com.rojoma.json.v3.io.JsonReader
 import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonKeyStrategy, Strategy}
-import org.elasticsearch.index.query._
+import org.elasticsearch.index.query.QueryBuilders
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._

--- a/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -15,8 +15,11 @@ object Filters {
     domains.map { ds => FilterBuilders.termsFilter(DomainFieldType.rawFieldName, ds.toSeq: _*) }
 
   def domainFilter(domain: String): Option[TermsFilterBuilder] =
-    if (domain.nonEmpty) Option(FilterBuilders.termsFilter(DomainFieldType.rawFieldName, domain))
-    else None
+    if (domain.nonEmpty) {
+      Option(FilterBuilders.termsFilter(DomainFieldType.rawFieldName, domain))
+    } else {
+      None
+    }
 
   def categoriesFilter(categories: Option[Set[String]]): Option[NestedFilterBuilder] =
     categories.map { cs =>

--- a/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -14,6 +14,10 @@ object Filters {
   def domainFilter(domains: Option[Set[String]]): Option[TermsFilterBuilder] =
     domains.map { ds => FilterBuilders.termsFilter(DomainFieldType.rawFieldName, ds.toSeq: _*) }
 
+  def domainFilter(domain: String): Option[TermsFilterBuilder] =
+    if (domain.nonEmpty) Option(FilterBuilders.termsFilter(DomainFieldType.rawFieldName, domain))
+    else None
+
   def categoriesFilter(categories: Option[Set[String]]): Option[NestedFilterBuilder] =
     categories.map { cs =>
       FilterBuilders.nestedFilter(

--- a/src/main/scala/com/socrata/cetera/search/Sorts.scala
+++ b/src/main/scala/com/socrata/cetera/search/Sorts.scala
@@ -1,0 +1,74 @@
+package com.socrata.cetera.search
+
+import org.elasticsearch.index.query.FilterBuilders
+import org.elasticsearch.search.sort.{FieldSortBuilder, SortBuilder, SortBuilders, SortOrder}
+
+import com.socrata.cetera.types._
+
+object Sorts {
+  val sortScoreDesc: SortBuilder = {
+    SortBuilders.scoreSort().order(SortOrder.DESC)
+  }
+
+  def sortFieldAsc(field: String): SortBuilder = {
+    SortBuilders.fieldSort(field).order(SortOrder.ASC)
+  }
+
+  def sortFieldDesc(field: String): SortBuilder = {
+    SortBuilders.fieldSort(field).order(SortOrder.DESC)
+  }
+
+  def buildAverageScoreSort(
+      fieldName: String,
+      rawFieldName: String,
+      classifications: Set[String])
+    : FieldSortBuilder = {
+
+    SortBuilders
+      .fieldSort(fieldName)
+      .order(SortOrder.DESC)
+      .sortMode("avg")
+      .setNestedFilter(
+        FilterBuilders.termsFilter(
+          rawFieldName,
+          classifications.toSeq: _*
+        )
+      )
+  }
+
+  // First pass logic is very simple. query >> categories >> tags >> default
+  def chooseSort(
+      searchQuery: QueryType,
+      searchContext: Option[Domain],
+      categories: Option[Set[String]],
+      tags: Option[Set[String]])
+    : SortBuilder = {
+
+    (searchQuery, categories, tags) match {
+      // Query
+      case (AdvancedQuery(_) | SimpleQuery(_), _, _) => Sorts.sortScoreDesc
+
+      // ODN Categories
+      // Q: What happens when we search according to domain_categories? It's not clear
+      case (_, Some(cats), _) if searchContext.isEmpty =>
+        buildAverageScoreSort(
+          CategoriesFieldType.Score.fieldName,
+          CategoriesFieldType.Name.rawFieldName,
+          cats
+        )
+
+      // ODN Tags
+      case (_, _, Some(ts)) if searchContext.isEmpty =>
+        buildAverageScoreSort(
+          TagsFieldType.Score.fieldName,
+          TagsFieldType.Name.rawFieldName,
+          ts
+        )
+
+      // Default (No query, categories, or tags)
+      case (_, _, _) =>
+        Sorts.sortFieldDesc(PageViewsTotalFieldType.fieldName)
+    }
+  }
+
+}

--- a/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
+++ b/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
@@ -4,7 +4,7 @@ import org.elasticsearch.index.query.functionscore.{FunctionScoreQueryBuilder, S
 import org.elasticsearch.index.query.{BoolQueryBuilder, MultiMatchQueryBuilder, QueryBuilders}
 import org.elasticsearch.search.sort.{SortBuilder, SortBuilders, SortOrder}
 
-import com.socrata.cetera.types.{DatatypeFieldType, Datatype, ScriptScoreFunction}
+import com.socrata.cetera.types.{Datatype, DatatypeFieldType, ScriptScoreFunction}
 
 object SundryBuilders {
   def addMinMatchConstraint(query: MultiMatchQueryBuilder, constraint: String): MultiMatchQueryBuilder =

--- a/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
+++ b/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
@@ -2,7 +2,6 @@ package com.socrata.cetera.search
 
 import org.elasticsearch.index.query.functionscore.{FunctionScoreQueryBuilder, ScoreFunctionBuilders}
 import org.elasticsearch.index.query.{BoolQueryBuilder, MultiMatchQueryBuilder, QueryBuilders}
-import org.elasticsearch.search.sort.{SortBuilder, SortBuilders, SortOrder}
 
 import com.socrata.cetera.types.{Datatype, DatatypeFieldType, ScriptScoreFunction}
 
@@ -24,9 +23,7 @@ object SundryBuilders {
 
   def boostTypes(typeBoosts: Map[Datatype, Float]): BoolQueryBuilder = {
     typeBoosts.foldLeft(QueryBuilders.boolQuery()) { case (q, (datatype, boost)) =>
-      typeBoosts.foldLeft(QueryBuilders.boolQuery()) { case (q, (datatype, boost)) =>
-        q.should(QueryBuilders.termQuery(DatatypeFieldType.fieldName, datatype.singular).boost(boost))
-      }
+      q.should(QueryBuilders.termQuery(DatatypeFieldType.fieldName, datatype.singular).boost(boost))
     }
   }
 
@@ -36,8 +33,4 @@ object SundryBuilders {
       .field("fts_raw")
       .field("domain_cname")
       .`type`(mmType)
-
-  val sortScoreDesc: SortBuilder = SortBuilders.scoreSort().order(SortOrder.DESC)
-  def sortFieldAsc(field: String): SortBuilder = SortBuilders.fieldSort(field).order(SortOrder.ASC)
-  def sortFieldDesc(field: String): SortBuilder = SortBuilders.fieldSort(field).order(SortOrder.DESC)
 }

--- a/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -7,7 +7,7 @@ import com.rojoma.json.v3.codec.DecodeError
 import com.rojoma.json.v3.io.JsonReader
 import com.rojoma.json.v3.matcher.{FirstOf, PObject, Variable}
 import com.socrata.http.server.implicits._
-import com.socrata.http.server.responses._
+import com.socrata.http.server.responses.{BadRequest, InternalServerError, Json, OK}
 import com.socrata.http.server.routing.SimpleResource
 import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import org.slf4j.LoggerFactory
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory
 import com.socrata.cetera._
 import com.socrata.cetera.search.{DocumentClient, DomainClient}
 import com.socrata.cetera.types._
-import com.socrata.cetera.util.JsonResponses._
+import com.socrata.cetera.util.JsonResponses.jsonError
 import com.socrata.cetera.util._
 
 class CountService(documentClient: DocumentClient, domainClient: DomainClient) {

--- a/src/main/scala/com/socrata/cetera/services/FacetService.scala
+++ b/src/main/scala/com/socrata/cetera/services/FacetService.scala
@@ -4,7 +4,7 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 import com.socrata.http.server.implicits._
-import com.socrata.http.server.responses._
+import com.socrata.http.server.responses.{BadRequest, InternalServerError, Json, OK}
 import com.socrata.http.server.routing.SimpleResource
 import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import org.elasticsearch.search.aggregations.bucket.filter.Filter

--- a/src/main/scala/com/socrata/cetera/services/VersionService.scala
+++ b/src/main/scala/com/socrata/cetera/services/VersionService.scala
@@ -1,7 +1,7 @@
 package com.socrata.cetera.services
 
 import com.socrata.http.server.implicits._
-import com.socrata.http.server.responses._
+import com.socrata.http.server.responses.{Content, OK}
 import com.socrata.http.server.routing.SimpleResource
 import com.socrata.http.server.{HttpRequest, HttpService}
 import org.slf4j.LoggerFactory

--- a/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -162,10 +162,15 @@ case object ColumnFieldNameFieldType extends Boostable {
   val fieldName: String = "indexed_metadata.columns_field_name"
 }
 
+case object DatatypeFieldType extends Boostable {
+  val fieldName: String = "datatype"
+}
+
+
+//////////////
+// For sorting
+
 case object PageViewsTotalFieldType extends CeteraFieldType {
   val fieldName: String = "page_views.page_views_total"
 }
 
-case object DatatypeFieldType extends Boostable {
-  val fieldName: String = "datatype"
-}

--- a/src/main/scala/com/socrata/cetera/util/ElasticsearchError.scala
+++ b/src/main/scala/com/socrata/cetera/util/ElasticsearchError.scala
@@ -1,5 +1,6 @@
 package com.socrata.cetera.util
 
+// The way this is used, we assume the error is coming from elasticsearch
 case class ElasticsearchError(originalMessage: String, stackTrace: Array[StackTraceElement]) extends Throwable {
   override def getStackTrace: Array[StackTraceElement] = stackTrace
   override def toString: String = shortMessage

--- a/src/main/scala/com/socrata/cetera/util/JsonResponses.scala
+++ b/src/main/scala/com/socrata/cetera/util/JsonResponses.scala
@@ -5,7 +5,7 @@ import java.io.{StringWriter, PrintWriter}
 import com.rojoma.json.v3.codec.JsonEncode
 import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, AutomaticJsonEncodeBuilder}
 import com.socrata.http.server.HttpResponse
-import com.socrata.http.server.responses._
+import com.socrata.http.server.responses.Json
 
 object JsonResponses {
   def jsonMessage(message: String): HttpResponse = {

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -440,9 +440,9 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
       actual.toString should be(expectedAsString)
     }
 
-    "not throw when cname is a null string" in {
+    "throw when cname is a null string" in {
       val cname: String = null // scalastyle:ignore
-      documentClient.buildFacetRequest(cname)
+      a [NullPointerException] should be thrownBy documentClient.buildFacetRequest(cname)
     }
   }
 

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -3,18 +3,27 @@ package com.socrata.cetera.search
 import com.rojoma.json.v3.interpolation._
 import com.rojoma.json.v3.io.JsonReader
 import org.elasticsearch.action.search.SearchType.COUNT
+import org.elasticsearch.search.sort.{SortBuilders, SortOrder}
 import org.scalatest.{BeforeAndAfterAll, ShouldMatchers, WordSpec}
 
-import com.socrata.cetera._
+import com.socrata.cetera.esDocumentType
 import com.socrata.cetera.types._
 import com.socrata.cetera.util.ValidatedQueryParameters
 
-////////////////////////////////////////////////////////
-// Brittleness deliberate. Query building not finalized.
+///////////////////////////////////////////////////////////////////////////////
+// NOTE: Regarding Brittleness
 //
-// Just to reiterate: VERY BRITTLE!!!
+// These tests are very brittle because they test (typically) the JSON blob
+// that gets sent to ES, and JSON blobs make no guarantees about order.
 //
-// JSON does not guarantee order.
+// Some of intermediate steps that do not yet produce JSON blobs simply test
+// the output of the toString function.
+//
+// These tests serve to codify expected behavior of our query builders.
+// (e.g, given the following user input, did we build the correct sort order?)
+// They do not test the correctness of those queries.
+//
+// Also note that a query builder is different from a request builder.
 
 class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
   val client = new TestESClient("esclientspec")  // Remember to close() me!!
@@ -32,7 +41,10 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     categories = Some(Set("Social Services", "Environment", "Housing & Development")),
     tags = Some(Set("taxi", "art", "clowns")),
     only = Some(Seq("datasets")),
-    fieldBoosts = Map[CeteraFieldType with Boostable, Float](TitleFieldType -> 2.2f, DescriptionFieldType -> 1.1f),
+    fieldBoosts = Map[CeteraFieldType with Boostable, Float](
+      TitleFieldType -> 2.2f,
+      DescriptionFieldType -> 1.1f
+    ),
     datatypeBoosts = Map.empty,
     minShouldMatch = None,
     slop = None,
@@ -42,172 +54,193 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   )
 
   val shouldMatch = j"""{
-    "multi_match" :
-      {
-        "query" : "search query terms",
-        "fields" :
-          [ "fts_analyzed", "fts_raw", "domain_cname" ],
-        "type" : "phrase"
-      }
+    "multi_match": {
+        "fields": [
+            "fts_analyzed",
+            "fts_raw",
+            "domain_cname"
+        ],
+        "query": "search query terms",
+        "type": "phrase"
+    }
   }"""
 
   val boolQuery = j"""{
-    "bool" :
-      {
-        "must" :
-          {
-            "multi_match" :
-              {
-                "query" : "search query terms",
-                "fields" :
-                  [ "fts_analyzed", "fts_raw", "domain_cname" ],
-                "type" : "cross_fields"
-              }
-          },
-        "should" :
-          ${shouldMatch}
-      }
+    "bool": {
+        "must": {
+            "multi_match": {
+                "fields": [
+                    "fts_analyzed",
+                    "fts_raw",
+                    "domain_cname"
+                ],
+                "query": "search query terms",
+                "type": "cross_fields"
+            }
+        },
+        "should": ${shouldMatch}
+    }
   }"""
 
   val boostedBoolQuery = j"""{
-    "bool" :
-      {
-        "must" :
-          {
-            "multi_match" :
-              {
-                "query" : "search query terms",
-                "fields" :
-                  [
+    "bool": {
+        "must": {
+            "multi_match": {
+                "fields": [
                     "fts_analyzed",
                     "fts_raw",
                     "domain_cname",
                     "indexed_metadata.name^2.2",
                     "indexed_metadata.description^1.1"
-                  ],
-                "type" : "cross_fields"
-              }
-          },
-        "should" :
-          ${shouldMatch}
-      }
+                ],
+                "query": "search query terms",
+                "type": "cross_fields"
+            }
+        },
+        "should": ${shouldMatch}
+    }
   }"""
 
   val moderationFilter = j"""{
-    "not" :
-      {
-        "filter" :
-          {
-            "terms" :
-              {
-                "moderation_status" :
-                  [ "pending", "rejected" ]
-              }
-          }
-      }
+    "not": {
+        "filter": {
+            "terms": {
+                "moderation_status": [
+                    "pending",
+                    "rejected"
+                ]
+            }
+        }
+    }
   }"""
 
   val customerDomainFilter = j"""{
-    "not" :
-      {
-        "filter" :
-          {
-            "terms" : {
-                        "is_customer_domain" : [ "false" ]
-                      }
-          }
-      }
+    "not": {
+        "filter": {
+            "terms": {
+                "is_customer_domain": [
+                    "false"
+                ]
+            }
+        }
+    }
   }"""
 
   val defaultFilter = j"""{
-    "and" :
-      {
-        "filters" :
-          [
+    "and": {
+        "filters": [
             ${moderationFilter},
             ${customerDomainFilter}
-          ]
-      }
+        ]
+    }
   }"""
 
-  val datatypeDatasetsFilter = j"""{ "terms" : { "datatype" : [ "dataset" ] } }"""
+  val datatypeDatasetsFilter = j"""{
+    "terms": {
+        "datatype": [
+            "dataset"
+        ]
+    }
+  }"""
 
   val domainFilter = j"""{
-    "terms" :
-      {
-        "socrata_id.domain_cname.raw" :
-          [
+    "terms": {
+        "socrata_id.domain_cname.raw": [
             "www.example.com",
             "test.example.com",
             "socrata.com"
-          ]
-      }
+        ]
+    }
   }"""
 
   val animlCategoriesFilter = j"""{
-    "nested" :
-      {
-        "filter" :
-          {
-            "terms" :
-              {
-                "animl_annotations.categories.name.raw" :
-                  [
+    "nested": {
+        "filter": {
+            "terms": {
+                "animl_annotations.categories.name.raw": [
                     "Social Services",
                     "Environment",
                     "Housing & Development"
-                  ]
-              }
-          },
-        "path" : "animl_annotations.categories"
-      }
+                ]
+            }
+        },
+        "path": "animl_annotations.categories"
+    }
   }"""
 
   val animlTagsFilter = j"""{
-    "nested" :
-    {
-      "filter" :
-        {
-          "terms" :
-            {
-              "animl_annotations.tags.name.raw" :
-                [ "taxi", "art", "clowns" ]
+    "nested": {
+        "filter": {
+            "terms": {
+                "animl_annotations.tags.name.raw": [
+                    "taxi",
+                    "art",
+                    "clowns"
+                ]
             }
         },
-      "path" : "animl_annotations.tags"
+        "path": "animl_annotations.tags"
     }
   }"""
 
   val complexFilter = j"""{
-    "and" :
-      {
-        "filters" :
-          [
+    "and": {
+        "filters": [
             ${datatypeDatasetsFilter},
             ${domainFilter},
             ${moderationFilter},
             ${customerDomainFilter},
             ${animlCategoriesFilter},
             ${animlTagsFilter}
-          ]
-      }
+        ]
+    }
   }"""
+
+
+  ////////////////////////
+  // buildAverageScoreSort
+  ////////////////////////
+
+  "buildAverageScoreSort" should {
+    "build a sort by average field score descending" in {
+      val fieldName = "this_looks_like.things"
+      val rawFieldName = "this_looks_like.things.raw"
+      val classifications = Set("one kind of thing", "another kind of thing")
+
+      // Using toString as proxy since toString does not give JSON parsable string
+      val expectedAsString = s"""
+         |"${fieldName}"{
+         |  "order" : "desc",
+         |  "mode" : "avg",
+         |  "nested_filter" : {
+         |    "terms" : {
+         |      "${rawFieldName}" : [ "${classifications.head}", "${classifications.last}" ]
+         |    }
+         |  }
+         |}""".stripMargin
+
+      val actual = documentClient.buildAverageScoreSort(fieldName, rawFieldName, classifications)
+
+      actual.toString should be (expectedAsString)
+    }
+  }
+
 
   ///////////////////
   // buildBaseRequest
-  //
+  ///////////////////
+
   "buildBaseRequest" should {
     "construct a default match all query" in {
       val expected = j"""{
-        "query" :
-          {
-            "filtered" :
-              {
-                "query" : { "match_all" : {} },
-                "filter" :
-                  ${defaultFilter}
-              }
-          }
+        "query": {
+            "filtered": {
+                "filter": ${defaultFilter},
+                "query": {
+                    "match_all": {}
+                }
+            }
+        }
       }"""
 
       val request = documentClient.buildBaseRequest(
@@ -230,16 +263,12 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
     "construct a match query with terms" in {
       val expected = j"""{
-        "query" :
-          {
-            "filtered" :
-              {
-                "query" :
-                  ${boolQuery},
-                "filter" :
-                  ${defaultFilter}
-              }
-          }
+        "query": {
+            "filtered": {
+                "filter": ${defaultFilter},
+                "query": ${boolQuery}
+            }
+        }
       }"""
 
       val request = documentClient.buildBaseRequest(
@@ -263,16 +292,12 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
     "construct a multi match query with boosted fields" in {
       val expected = j"""{
-        "query" :
-          {
-            "filtered" :
-              {
-                "query" :
-                  ${boostedBoolQuery},
-                "filter" :
-                  ${defaultFilter}
-              }
-          }
+        "query": {
+            "filtered": {
+                "filter": ${defaultFilter},
+                "query": ${boostedBoolQuery}
+            }
+        }
       }"""
 
       val request = documentClient.buildBaseRequest(
@@ -296,25 +321,179 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   }
 
 
+  ////////////////////
+  // buildCountRequest
+  // /////////////////
+
+  "buildCountRequest" should {
+    "construct a default search query with normal aggregation for domains" in {
+      val expected = j"""{
+        "aggregations": {
+            "domains": {
+                "terms": {
+                    "field": "socrata_id.domain_cname.raw",
+                    "order": {
+                        "_count": "desc"
+                    },
+                    "size": 0
+                }
+            }
+        },
+        "query": {
+            "filtered": {
+                "filter": ${defaultFilter},
+                "query": {
+                    "match_all": {}
+                }
+            }
+        }
+      }"""
+
+      val request = documentClient.buildCountRequest(
+        field = DomainFieldType,
+        searchQuery = NoQuery,
+        domains = None,
+        searchContext = None,
+        categories = None,
+        tags = None,
+        only = None
+      )
+
+      val actual = JsonReader.fromString(request.toString)
+
+      actual should be (expected)
+      request.request.searchType should be (COUNT)
+    }
+
+    "construct a filtered match query with nested aggregation for annotations" in {
+      val expected = j"""{
+        "aggregations": {
+            "annotations": {
+                "aggregations": {
+                    "names": {
+                        "terms": {
+                            "field": "animl_annotations.categories.name.raw",
+                            "size": 0
+                        }
+                    }
+                },
+                "nested": {
+                    "path": "animl_annotations.categories"
+                }
+            }
+        },
+        "query": {
+            "filtered": {
+                "filter": ${complexFilter},
+                "query": ${boolQuery}
+            }
+        }
+      }"""
+
+      val request = documentClient.buildCountRequest(
+        CategoriesFieldType,
+        searchQuery = params.searchQuery,
+        domains = params.domains,
+        searchContext = None,
+        categories = params.categories,
+        tags = params.tags,
+        only = params.only
+      )
+
+      val actual = JsonReader.fromString(request.toString)
+
+      actual should be (expected)
+      request.request.searchType should be (COUNT)
+    }
+  }
+
+
+  ////////////////////
+  // buildFacetRequest
+  ////////////////////
+
+  "buildFacetRequest" should {
+    val cname = "example.com"
+    val expectedAsString = s"""{
+      |  "size" : 0,
+      |  "aggregations" : {
+      |    "domain_filter" : {
+      |      "filter" : {
+      |        "terms" : {
+      |          "socrata_id.domain_cname.raw" : [ "${cname}" ]
+      |        }
+      |      },
+      |      "aggregations" : {
+      |        "datatypes" : {
+      |          "terms" : {
+      |            "field" : "datatype",
+      |            "size" : 0
+      |          }
+      |        },
+      |        "categories" : {
+      |          "terms" : {
+      |            "field" : "customer_category.raw",
+      |            "size" : 0
+      |          }
+      |        },
+      |        "tags" : {
+      |          "terms" : {
+      |            "field" : "customer_tags.raw",
+      |            "size" : 0
+      |          }
+      |        },
+      |        "metadata" : {
+      |          "nested" : {
+      |            "path" : "customer_metadata_flattened"
+      |          },
+      |          "aggregations" : {
+      |            "keys" : {
+      |              "terms" : {
+      |                "field" : "customer_metadata_flattened.key.raw",
+      |                "size" : 0
+      |              },
+      |              "aggregations" : {
+      |                "values" : {
+      |                  "terms" : {
+      |                    "field" : "customer_metadata_flattened.value.raw",
+      |                    "size" : 0
+      |                  }
+      |                }
+      |              }
+      |            }
+      |          }
+      |        }
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+
+    val actual = documentClient.buildFacetRequest(cname)
+
+    actual.toString should be(expectedAsString)
+  }
+
+
   /////////////////////
   // buildSearchRequest
-  //
+  /////////////////////
+
   "buildSearchRequest" should {
     "add from, size, sort and only to a complex base request" in {
       val expected = j"""{
-        "from" : ${params.offset},
-        "size" : ${params.limit},
-        "query" :
-          {
-            "filtered" :
-              {
-                "query" :
-                  ${boolQuery},
-                "filter" :
-                  ${complexFilter}
-              }
-          },
-        "sort" : [ { "_score" : {} } ]
+        "from": ${params.offset},
+        "query": {
+            "filtered": {
+                "filter": ${complexFilter},
+                "query": ${boolQuery}
+            }
+        },
+        "size": ${params.limit},
+        "sort": [
+            {
+                "_score": {}
+            }
+        ]
       }"""
 
       val request = documentClient.buildSearchRequest(
@@ -341,39 +520,33 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
     "sort by categories score when query term is missing but cat filter is present" in {
       val expected = j"""{
-        "from" : ${params.offset},
-        "size" : ${params.limit},
-        "query" :
-          {
-            "filtered" :
-              {
-                "query" : { "match_all" : {} },
-                "filter" :
-                  ${complexFilter}
-              }
-          },
-        "sort" :
-          [
-            {
-              "animl_annotations.categories.score" :
-                {
-                  "order" : "desc",
-                  "mode" : "avg",
-                  "nested_filter" :
-                    {
-                      "terms" :
-                        {
-                          "animl_annotations.categories.name.raw" :
-                            [
-                              "Social Services",
-                              "Environment",
-                              "Housing & Development"
-                            ]
-                        }
-                    }
+        "from": ${params.offset},
+        "query": {
+            "filtered": {
+                "filter": ${complexFilter},
+                "query": {
+                    "match_all": {}
                 }
             }
-          ]
+        },
+        "size": ${params.limit},
+        "sort": [
+            {
+                "animl_annotations.categories.score": {
+                    "mode": "avg",
+                    "nested_filter": {
+                        "terms": {
+                            "animl_annotations.categories.name.raw": [
+                                "Social Services",
+                                "Environment",
+                                "Housing & Development"
+                            ]
+                        }
+                    },
+                    "order": "desc"
+                }
+            }
+        ]
       }"""
 
       val request = documentClient.buildSearchRequest(
@@ -400,97 +573,144 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   }
 
 
-  ////////////////////
-  // buildCountRequest
-  //
-  "buildCountRequest" should {
-    "construct a default search query with normal aggregation for domains" in {
-      val expected = j"""{
-        "query" :
-          {
-            "filtered" :
-              {
-                "query" : { "match_all" : {} },
-                "filter" :
-                  ${defaultFilter}
-              }
-          },
-        "aggregations" :
-          {
-            "domains" :
-              {
-                "terms" :
-                  {
-                    "field" : "socrata_id.domain_cname.raw",
-                    "size" : 0,
-                    "order" : { "_count" : "desc" }
-                  }
-              }
-          }
-      }"""
+  ////////////
+  // buildSort
+  ////////////
 
-      val request = documentClient.buildCountRequest(
-        field = DomainFieldType,
+  // TODO: Really, these should check that the correct sort fns are getting
+  // called, and separate tests for sort fns should test the expected strings.
+  // We'll double these up for now and possibly split them out later.
+
+  "buildSort" should {
+    // Be sure that you do provide extraneous fields when possible
+    "order by page views descending for default null query" in {
+      val expected = SundryBuilders.sortFieldDesc("page_views.page_views_total")
+      val expectedAsString = s"""
+        |"page_views.page_views_total"{
+        |  "order" : "desc"
+        |}""".stripMargin
+
+      expected.toString should be(expectedAsString)
+
+      val actual = documentClient.buildSort(
         searchQuery = NoQuery,
-        domains = None,
         searchContext = None,
         categories = None,
-        tags = None,
-        only = None
+        tags = None
       )
 
-      val actual = JsonReader.fromString(request.toString)
-
-      actual should be (expected)
-      request.request.searchType should be (COUNT)
+      actual.toString should be (expectedAsString)
     }
 
-    "construct a filtered match query with nested aggregation for annotations" in {
-      val expected = j"""{
-        "query" :
-          {
-            "filtered" :
-              {
-                "query" :
-                  ${boolQuery},
-                "filter" :
-                  ${complexFilter}
-              }
-          },
-        "aggregations" :
-          {
-            "annotations" :
-              {
-                "nested" : { "path" : "animl_annotations.categories" },
-                "aggregations" :
-                  {
-                    "names" :
-                      {
-                        "terms" :
-                          {
-                            "field" : "animl_annotations.categories.name.raw",
-                            "size" : 0
-                          }
-                      }
-                  }
-              }
-          }
-      }"""
+    "order by query score descending when given an advanced query" in {
+      val expected = SundryBuilders.sortScoreDesc
+      val expectedAsString = s"""
+        |"_score"{ }""".stripMargin
 
-      val request = documentClient.buildCountRequest(
-        CategoriesFieldType,
-        searchQuery = params.searchQuery,
-        domains = params.domains,
+      expected.toString should be(expectedAsString)
+
+      val actual = documentClient.buildSort(
+        searchQuery = AdvancedQuery("sandwich AND (soup OR salad)"),
         searchContext = None,
-        categories = params.categories,
-        tags = params.tags,
-        only = params.only
+        categories = None,
+        tags = None
       )
 
-      val actual = JsonReader.fromString(request.toString)
+      actual.toString should be(expectedAsString)
+    }
 
-      actual should be (expected)
-      request.request.searchType should be (COUNT)
+    "order by query score desc when given a simple query" in {
+      val expected = SundryBuilders.sortScoreDesc
+      val expectedAsString = s"""
+        |"_score"{ }""".stripMargin
+
+      expected.toString should be(expectedAsString)
+
+      val actual = documentClient.buildSort(
+        searchQuery = SimpleQuery("soup salad sandwich"),
+        searchContext = None,
+        categories = None,
+        tags = None
+      )
+
+      actual should be(expected)
+    }
+
+    "order by average category score descending when no query but ODN categories present" in {
+      val cats = Set[String]("comestibles", "potables")
+      val tags = Set[String]("tasty", "sweet", "taters", "precious")
+
+      val expectedAsString = s"""
+        |"animl_annotations.categories.score"{
+        |  "order" : "desc",
+        |  "mode" : "avg",
+        |  "nested_filter" : {
+        |    "terms" : {
+        |      "animl_annotations.categories.name.raw" : [ "${cats.head}", "${cats.last}" ]
+        |    }
+        |  }
+        |}""".stripMargin
+
+      val actual = documentClient.buildSort(
+        searchQuery = NoQuery,
+        searchContext = None,
+        categories = Some(cats),
+        tags = Some(tags)
+      )
+
+      actual.toString should be(expectedAsString)
+    }
+
+    "order by average tag score desc when no query or categories but ODN tags present" in {
+      val tags = Set[String]("tasty", "sweet", "taters", "precious")
+      val tagsJson = "[ \"" + tags.mkString("\", \"") + "\" ]"
+
+      val expectedAsString = s"""
+        |"animl_annotations.tags.score"{
+        |  "order" : "desc",
+        |  "mode" : "avg",
+        |  "nested_filter" : {
+        |    "terms" : {
+        |      "animl_annotations.tags.name.raw" : ${tagsJson}
+        |    }
+        |  }
+        |}""".stripMargin
+
+      val actual = documentClient.buildSort(
+        searchQuery = NoQuery,
+        searchContext = None,
+        categories = None,
+        tags = Some(tags)
+      )
+
+      actual.toString should be(expectedAsString)
+    }
+
+    // Be sure that you do provide extraneous fields when possible
+    "order by page views DESC when given no query, categories, or tags" in {
+    }
+  }
+
+
+  ////////////////
+  // generateQuery
+  ////////////////
+
+  "generateQuery" should {
+    "generate a match all query by default" in {
+      val expectedAsString = s"""{
+        |  "match_all" : { }
+        |}""".stripMargin
+
+      val actual = documentClient.generateQuery(
+        searchQuery = NoQuery,
+        fieldBoosts = Map.empty,
+        typeBoosts = Map.empty,
+        minShouldMatch = None,
+        slop = None
+      )
+
+      actual.toString should be(expectedAsString)
     }
   }
 }

--- a/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
@@ -1,0 +1,175 @@
+package com.socrata.cetera.search
+
+import org.scalatest.{BeforeAndAfterAll, ShouldMatchers, WordSpec}
+
+import com.socrata.cetera.types.{AdvancedQuery, NoQuery, SimpleQuery}
+
+// NOTE: The toString method of the SortBuilders does not produce
+// JSON-parseable output. So, we test the output of the toString method as a
+// proxy for equality.
+
+class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
+  "sortScoreDesc" should {
+    "sort by score descending" in {
+      val expectedAsString = s"""
+        |"_score"{ }""".stripMargin
+
+      val actual = Sorts.sortScoreDesc
+
+      actual.toString should be (expectedAsString)
+    }
+  }
+
+  "sortFieldAsc" should {
+    "sort by a given field ascending" in {
+      val field = "field.in.our.documents"
+      val expectedAsString = s"""
+        |"${field}"{
+        |  "order" : "asc"
+        |}""".stripMargin
+
+      val actual = Sorts.sortFieldAsc(field)
+
+      actual.toString should be(expectedAsString)
+    }
+  }
+
+  "sortFieldDesc" should {
+    "sort by a given field descending" in {
+      val field = "another_field.another_field_total"
+      val expectedAsString = s"""
+        |"${field}"{
+        |  "order" : "desc"
+        |}""".stripMargin
+
+      val actual = Sorts.sortFieldDesc(field)
+
+      actual.toString should be(expectedAsString)
+    }
+  }
+
+  "buildAverageScoreSort" should {
+    "build a sort by average field score descending" in {
+      val fieldName = "this_looks_like.things"
+      val rawFieldName = "this_looks_like.things.raw"
+      val classifications = Set("one kind of thing", "another kind of thing")
+
+      // Using toString as proxy since toString does not give JSON parsable string
+      val expectedAsString = s"""
+         |"${fieldName}"{
+         |  "order" : "desc",
+         |  "mode" : "avg",
+         |  "nested_filter" : {
+         |    "terms" : {
+         |      "${rawFieldName}" : [ "${classifications.head}", "${classifications.last}" ]
+         |    }
+         |  }
+         |}""".stripMargin
+
+      val actual = Sorts.buildAverageScoreSort(fieldName, rawFieldName, classifications)
+
+      actual.toString should be (expectedAsString)
+    }
+  }
+
+  "chooseSort" should {
+    val cats = Set[String]("comestibles", "potables")
+    val tags = Set[String]("tasty", "sweet", "taters", "precious")
+
+    "order by query score descending when given an advanced query" in {
+      val expected = Sorts.sortScoreDesc
+
+      val actual = Sorts.chooseSort(
+        searchQuery = AdvancedQuery("sandwich AND (soup OR salad)"),
+        searchContext = None,
+        categories = None,
+        tags = Some(tags)
+      )
+
+      // sortScores is a val so it's the same object
+      actual should be(expected)
+    }
+
+    "order by query score desc when given a simple query" in {
+      val expected = Sorts.sortScoreDesc
+
+      val searchContext = Domain(
+        isCustomerDomain = false,
+        organization = Some("SDP"),
+        domainCname = "peterschneider.net",
+        siteTitle = Some("Temporary URI"),
+        moderationEnabled = false,
+        routingApprovalEnabled = true
+      )
+
+      val actual = Sorts.chooseSort(
+        searchQuery = SimpleQuery("soup salad sandwich"),
+        searchContext = Some(searchContext),
+        categories = Some(cats),
+        tags = None
+      )
+
+      // sortScores is a val so it's the same object
+      actual should be(expected)
+    }
+
+    "order by average category score descending when no query but ODN categories present" in {
+      val expectedAsString = s"""
+        |"animl_annotations.categories.score"{
+        |  "order" : "desc",
+        |  "mode" : "avg",
+        |  "nested_filter" : {
+        |    "terms" : {
+        |      "animl_annotations.categories.name.raw" : [ "${cats.head}", "${cats.last}" ]
+        |    }
+        |  }
+        |}""".stripMargin
+
+      val actual = Sorts.chooseSort(
+        searchQuery = NoQuery,
+        searchContext = None,
+        categories = Some(cats),
+        tags = Some(tags)
+      )
+
+      actual.toString should be(expectedAsString)
+    }
+
+    "order by average tag score desc when no query or categories but ODN tags present" in {
+      val tagsJson = "[ \"" + tags.mkString("\", \"") + "\" ]"
+
+      val expectedAsString = s"""
+        |"animl_annotations.tags.score"{
+        |  "order" : "desc",
+        |  "mode" : "avg",
+        |  "nested_filter" : {
+        |    "terms" : {
+        |      "animl_annotations.tags.name.raw" : ${tagsJson}
+        |    }
+        |  }
+        |}""".stripMargin
+
+      val actual = Sorts.chooseSort(
+        searchQuery = NoQuery,
+        searchContext = None,
+        categories = None,
+        tags = Some(tags)
+      )
+
+      actual.toString should be(expectedAsString)
+    }
+
+    "order by page views descending for default null query" in {
+      val expected = Sorts.sortFieldDesc("page_views.page_views_total")
+
+      val actual = Sorts.chooseSort(
+        searchQuery = NoQuery,
+        searchContext = None,
+        categories = None,
+        tags = None
+      )
+
+      actual.toString should be (expected.toString)
+    }
+  }
+}


### PR DESCRIPTION
This cleans up the DocumentClient and its Spec in preparation for further work such as sorting:
* Decomposes some big methods into smaller ones and adds unit tests for these.
* Breaks out the Sorts into their own object/file (with their own Spec)
* Cleans up some of the JSON payloads in the Specs (using python -m json.tool)
* Introduces [Spark Style](https://github.com/databricks/scala-style-guide) to the DocumentClient.
  - Normally one shouldn't make style changes willy nilly but we lost the git history anyway from recent (much needed) reorganization.

I have been looking at this batch of commits too long and likely have left something in or forgotten something.