### PR TITLE
EN-2361 categories and tags case insensitive

### DIFF
--- a/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -21,30 +21,38 @@ object Filters {
   def domainFilter(domain: String): Option[TermsFilterBuilder] =
     if (domain.nonEmpty) domainFilter(Set(domain)) else None
 
-  def categoriesFilter(categories: Option[Set[String]]): Option[NestedFilterBuilder] =
+  def categoriesQuery(categories: Option[Set[String]]): Option[QueryBuilder] =
     categories.map { cs =>
-      FilterBuilders.nestedFilter(
+      QueryBuilders.nestedQuery(
         CategoriesFieldType.fieldName,
-        FilterBuilders.termsFilter(CategoriesFieldType.Name.rawFieldName, cs.toSeq: _*)
+        cs.foldLeft(QueryBuilders.boolQuery().minimumNumberShouldMatch(1)) { (b, q) =>
+          b.should(QueryBuilders.matchQuery(CategoriesFieldType.Name.fieldName, q))
+        }
       )
     }
 
-  def tagsFilter(tags: Option[Set[String]]): Option[NestedFilterBuilder] =
+  def tagsQuery(tags: Option[Set[String]]): Option[QueryBuilder] =
     tags.map { tags =>
-      FilterBuilders.nestedFilter(
+      QueryBuilders.nestedQuery(
         TagsFieldType.fieldName,
-        FilterBuilders.termsFilter(TagsFieldType.Name.rawFieldName, tags.toSeq: _*)
+        tags.foldLeft(QueryBuilders.boolQuery().minimumNumberShouldMatch(1)) { (b, q) =>
+          b.should(QueryBuilders.matchQuery(TagsFieldType.Name.fieldName, q))
+        }
       )
     }
 
-  def domainCategoriesFilter(categories: Option[Set[String]]): Option[TermsFilterBuilder] =
+  def domainCategoriesQuery(categories: Option[Set[String]]): Option[QueryBuilder] =
     categories.map { cs =>
-      FilterBuilders.termsFilter(DomainCategoryFieldType.rawFieldName, cs.toSeq: _*)
+      cs.foldLeft(QueryBuilders.boolQuery().minimumNumberShouldMatch(1)) { (b, q) =>
+        b.should(QueryBuilders.matchQuery(DomainCategoryFieldType.fieldName, q))
+      }
     }
 
-  def domainTagsFilter(tags: Option[Set[String]]): Option[TermsFilterBuilder] =
+  def domainTagsQuery(tags: Option[Set[String]]): Option[QueryBuilder] =
     tags.map { ts =>
-      FilterBuilders.termsFilter(DomainTagsFieldType.rawFieldName, ts.toSeq: _*)
+      ts.foldLeft(QueryBuilders.boolQuery().minimumNumberShouldMatch(1)) { (b, q) =>
+        b.should(QueryBuilders.multiMatchQuery(DomainTagsFieldType.fieldName, q))
+      }
     }
 
   def domainMetadataFilter(metadata: Option[Set[(String, String)]]): Option[OrFilterBuilder] =

--- a/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
+++ b/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
@@ -130,7 +130,7 @@ object QueryParametersParser {
           queryStringDomainMetadata(queryParameters),
           queryParameters.first(Params.context).map(_.toLowerCase),
           mergeParams(queryParameters, Set(Params.filterCategories, Params.filterCategoriesArray)),
-          mergeParams(queryParameters, Set(Params.filterTags, Params.filterTagsArray), _.toLowerCase),
+          mergeParams(queryParameters, Set(Params.filterTags, Params.filterTagsArray)),
           o,
           fieldBoosts,
           datatypeBoosts,

--- a/src/test/resources/base.json
+++ b/src/test/resources/base.json
@@ -211,6 +211,7 @@
               "properties" : {
                 "name" : {
                   "type" : "string",
+                  "analyzer": "case_insensitive_en",
                   "copy_to": [ "fts_analyzed", "fts_raw" ],
                   "fields" : {
                     "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
@@ -225,6 +226,7 @@
               "properties" : {
                 "name" : {
                   "type" : "string",
+                  "analyzer": "case_insensitive_en",
                   "copy_to": [ "fts_analyzed", "fts_raw" ],
                   "fields" : {
                     "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
@@ -238,6 +240,7 @@
         },
         "customer_tags" : {
           "type" : "string",
+          "analyzer": "case_insensitive_en",
           "copy_to": [ "fts_analyzed", "fts_raw" ],
           "fields": {
             "raw" : {"type" : "string", "index" : "not_analyzed"},
@@ -246,6 +249,7 @@
         },
         "customer_category" : {
           "type" : "string",
+          "analyzer": "case_insensitive_en",
           "copy_to": [ "fts_analyzed", "fts_raw" ],
           "fields" : {
             "raw" : {"type" : "string", "index" : "not_analyzed"},

--- a/src/test/resources/base.json
+++ b/src/test/resources/base.json
@@ -63,37 +63,42 @@
           "properties" : {
             "columns_description" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "columns_name" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "columns_field_name" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "description" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "name" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             }
           },
@@ -101,7 +106,6 @@
         },
         "resource" : {
           "enabled" : false,
-          "index" : "no",
           "type" : "nested",
           "properties" : {
             "page_views" : {
@@ -123,6 +127,9 @@
             "nbe_fxf" : {
               "type" : "string"
             },
+            "obe_fxf" : {
+              "type" : "string"
+            },
             "id" : {
               "type" : "string"
             },
@@ -137,23 +144,26 @@
             },
             "columns_description" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "columns_name" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "columns_field_name" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             }
           }
@@ -166,9 +176,10 @@
             "domain_cname" : {
               "type" : "string",
               "analyzer" : "simple",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "domain_id" : {
@@ -176,16 +187,18 @@
             },
             "organization" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "site_title" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             }
           },
@@ -198,9 +211,10 @@
               "properties" : {
                 "name" : {
                   "type" : "string",
+                  "copy_to": [ "fts_analyzed", "fts_raw" ],
                   "fields" : {
-                    "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                    "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                    "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
+                    "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
                   }
                 },
                 "score" : {"type" : "float", "store" : "no", "index" : "not_analyzed"}
@@ -211,9 +225,10 @@
               "properties" : {
                 "name" : {
                   "type" : "string",
+                  "copy_to": [ "fts_analyzed", "fts_raw" ],
                   "fields" : {
-                    "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                    "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                    "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
+                    "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
                   }
                 },
                 "score" : {"type" : "float", "store" : "no", "index" : "not_analyzed"}
@@ -223,16 +238,18 @@
         },
         "customer_tags" : {
           "type" : "string",
+          "copy_to": [ "fts_analyzed", "fts_raw" ],
           "fields": {
-            "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-            "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+            "raw" : {"type" : "string", "index" : "not_analyzed"},
+            "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
           }
         },
         "customer_category" : {
           "type" : "string",
+          "copy_to": [ "fts_analyzed", "fts_raw" ],
           "fields" : {
-            "raw" : {"type" : "string", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-            "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+            "raw" : {"type" : "string", "index" : "not_analyzed"},
+            "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
           }
         },
         "customer_metadata_flattened" : {
@@ -240,16 +257,18 @@
           "properties" : {
             "key" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             },
             "value" : {
               "type" : "string",
+              "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed", "copy_to" : "fts_raw"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en", "copy_to" : "fts_analyzed"}
+                "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
+                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
               }
             }
           }

--- a/src/test/resources/settings.json
+++ b/src/test/resources/settings.json
@@ -2,10 +2,22 @@
   "settings": {
     "index": {
       "analysis": {
+        "filter": {
+          "lowercase_en": {
+            "type": "lowercase"
+          }
+        },
         "analyzer": {
           "snowball_en": {
             "type": "snowball",
             "language": "English"
+          },
+          "case_insensitive_en": {
+            "type": "custom",
+            "filter": [
+              "lowercase_en"
+            ],
+            "tokenizer": "keyword"
           }
         }
       },

--- a/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -297,4 +297,70 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
       expectedFxfs.contains(id) should be(true)
     }
   }
+
+  test("categories filter should be case insensitive") {
+    val paramsTitleCase = Map(
+      "domains" -> Seq("petercetera.net"),
+      "categories" -> Seq("Personal")
+    )
+    val paramsLowerCase = paramsTitleCase.mapValues(_.map(_.toLowerCase))
+    val paramsUpperCase = paramsTitleCase.mapValues(_.map(_.toUpperCase))
+
+    val (resultsTitleCase, _) = service.doSearch(paramsTitleCase)
+    val (resultsLowerCase, _) = service.doSearch(paramsLowerCase)
+    val (resultsUpperCase, _) = service.doSearch(paramsUpperCase)
+
+    resultsTitleCase.results should contain theSameElementsAs resultsLowerCase.results
+    resultsTitleCase.results should contain theSameElementsAs resultsUpperCase.results
+  }
+
+  test("custom domain categories filter should be case insensitive") {
+    val paramsTitleCase = Map(
+      "domains" -> Seq("petercetera.net"),
+      "search_context" -> Seq("petercetera.net"),
+      "categories" -> Seq("Alpha")
+    )
+    val paramsLowerCase = paramsTitleCase.mapValues(_.map(_.toLowerCase))
+    val paramsUpperCase = paramsTitleCase.mapValues(_.map(_.toUpperCase))
+
+    val (resultsTitleCase, _) = service.doSearch(paramsTitleCase)
+    val (resultsLowerCase, _) = service.doSearch(paramsLowerCase)
+    val (resultsUpperCase, _) = service.doSearch(paramsUpperCase)
+
+    resultsTitleCase.results should contain theSameElementsAs resultsLowerCase.results
+    resultsTitleCase.results should contain theSameElementsAs resultsUpperCase.results
+  }
+
+  test("tags filter should be case insensitive") {
+    val paramsTitleCase = Map(
+      "domains" -> Seq("petercetera.net"),
+      "tags" -> Seq("Happy")
+    )
+    val paramsLowerCase = paramsTitleCase.mapValues(_.map(_.toLowerCase))
+    val paramsUpperCase = paramsTitleCase.mapValues(_.map(_.toUpperCase))
+
+    val (resultsTitleCase, _) = service.doSearch(paramsTitleCase)
+    val (resultsLowerCase, _) = service.doSearch(paramsLowerCase)
+    val (resultsUpperCase, _) = service.doSearch(paramsUpperCase)
+
+    resultsTitleCase.results should contain theSameElementsAs resultsLowerCase.results
+    resultsTitleCase.results should contain theSameElementsAs resultsUpperCase.results
+  }
+
+  test("custom domain tags filter should be case insensitive") {
+    val paramsTitleCase = Map(
+      "domains" -> Seq("petercetera.net"),
+      "search_context" -> Seq("petercetera.net"),
+      "tags" -> Seq("1-One")
+    )
+    val paramsLowerCase = paramsTitleCase.mapValues(_.map(_.toLowerCase))
+    val paramsUpperCase = paramsTitleCase.mapValues(_.map(_.toUpperCase))
+
+    val (resultsTitleCase, _) = service.doSearch(paramsTitleCase)
+    val (resultsLowerCase, _) = service.doSearch(paramsLowerCase)
+    val (resultsUpperCase, _) = service.doSearch(paramsUpperCase)
+
+    resultsTitleCase.results should contain theSameElementsAs resultsLowerCase.results
+    resultsTitleCase.results should contain theSameElementsAs resultsUpperCase.results
+  }
 }

--- a/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
+++ b/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
@@ -145,7 +145,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
       case Right(params) =>
         params.tags should be('defined)
         params.tags.get should have size 3
-        params.tags.get should contain theSameElementsAs Seq("traffic", "parking", "transportation")
+        params.tags.get should contain theSameElementsAs Seq("Traffic", "Parking", "Transportation")
       case _ => fail()
     }
   }


### PR DESCRIPTION
* note that most of the es mapping changes are just to get in sync with current state of etl
* categories (both odn and custom domain) are now case insensitive
  * added elasticsearch mapping for case insensitivity
* tags (both odn and custom domain) are still case insensitive
  * deleted the toLowerCase call in query path
  * added elasticsearch mapping for case insensitivity

Paired-with: @kavedder 

Depends on https://github.com/socrata/cetera-etl/pull/170

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata/cetera/118)
<!-- Reviewable:end -->
