### PR TITLE
EN-2367 Add balboa client for keeping metrics on search terms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,12 @@ crossScalaVersions := Seq("2.10.4", scalaVersion.value)
 
 resolvers ++= Seq(
   "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/",
-  "socrata internal maven" at "https://repo.socrata.com/artifactory/simple/libs-release-local",
-  "socrata maven" at "https://repository-socrata-oss.forge.cloudbees.com/release",
-  "socrata maven-snap" at "https://repository-socrata-oss.forge.cloudbees.com/snapshot",
+  "Artifactory release" at "https://repo.socrata.com/artifactory/simple/libs-release-local",
+  "Artifactory snapshot" at "https://repo.socrata.com/artifactory/simple/libs-snapshot-local",
+  "Cloudbees release" at "https://repository-socrata-oss.forge.cloudbees.com/release",
+  "Cloudbees snapshot" at "https://repository-socrata-oss.forge.cloudbees.com/snapshot",
   Classpaths.sbtPluginReleases,
-  Resolver.url("socrata ivy", new URL("https://repo.socrata.com/artifactory/ivy-libs-release"))(Resolver.ivyStylePatterns)
+  Resolver.url("Artifactory ivy", new URL("https://repo.socrata.com/artifactory/ivy-libs-release"))(Resolver.ivyStylePatterns)
 )
 
 val rojomaDependencies = Seq(
@@ -21,7 +22,8 @@ val rojomaDependencies = Seq(
 val socrataDependencies = Seq(
   "com.socrata" %% "socrata-http-client" % "3.5.0",
   "com.socrata" %% "socrata-http-jetty" % "3.5.0",
-  "com.socrata" %% "socrata-thirdparty-utils" % "4.0.12"
+  "com.socrata" %% "socrata-thirdparty-utils" % "4.0.12",
+  "com.socrata" %% "balboa-client" % "0.16.15"
 ).map { _.excludeAll(ExclusionRule(organization = "com.rojoma")) }
 
 val loggingDependencies = Seq(

--- a/cetera.conf.j2
+++ b/cetera.conf.j2
@@ -25,6 +25,10 @@ com.socrata {
     }
   }
 
+  balboa {
+    data-directory = {{ BALBOA_METRICS_DIRECTORY }}
+  }
+
   elasticsearch {
     es-server = {{ ES_SERVER }}
     es-port = {{ ES_PORT }}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -25,6 +25,10 @@ com.socrata {
     }
   }
 
+  balboa {
+    data-directory = "/tmp/metrics"
+  }
+
   elasticsearch {
     es-server = "127.0.0.1"
     es-port = 9300

--- a/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 
 import com.socrata.cetera.config.CeteraConfig
 import com.socrata.cetera.handlers.Router
+import com.socrata.cetera.metrics.BalboaClient
 import com.socrata.cetera.search.{DocumentClient, DomainClient, ElasticSearchClient}
 import com.socrata.cetera.services.{CountService, FacetService, SearchService, VersionService}
 import com.socrata.cetera.types.ScriptScoreFunction
@@ -70,11 +71,14 @@ object SearchServer extends App {
     logger.info("ElasticSearchClient initialized on nodes " +
                   esClient.client.asInstanceOf[TransportClient].transportAddresses().toString)
 
+    logger.info("Initializing BalboClient")
+    val balboaClient = new BalboaClient(config.balboa.dataDirectory)
+
     logger.info("Initializing VersionService")
     val versionService = VersionService
 
     logger.info("Initializing SearchService with Elasticsearch TransportClient")
-    val searchService = new SearchService(documentClient, domainClient)
+    val searchService = new SearchService(documentClient, domainClient, balboaClient)
 
     logger.info("Initializing FacetService with Elasticsearch TransportClient")
     val facetService = new FacetService(documentClient)

--- a/src/main/scala/com/socrata/cetera/config/AppConfig.scala
+++ b/src/main/scala/com/socrata/cetera/config/AppConfig.scala
@@ -13,7 +13,7 @@ class CeteraConfig(config: Config) extends ConfigClass(config, "com.socrata") {
   val log4j = getRawConfig("log4j")
   val http = getConfig("http", new HttpConfig(_, _))
   val elasticSearch = getConfig("elasticsearch", new ElasticSearchConfig(_,_))
-
+  val balboa =  getConfig("balboa", new BalboaConfig(_, _))
   val debugString = config.root.render()
 }
 
@@ -30,6 +30,10 @@ class LivenessConfig(config: Config, root: String) extends ConfigClass(config, r
 class ServerConfig(config: Config, root: String) extends ConfigClass(config, root) {
   val port = getInt("port")
   val gracefulShutdownTimeout = getDuration("graceful-shutdown-time")
+}
+
+class BalboaConfig(config: Config, root: String) extends ConfigClass(config, root) {
+  val dataDirectory = getString("data-directory")
 }
 
 class ElasticSearchConfig(config:Config, root:String) extends ConfigClass(config,root) {

--- a/src/main/scala/com/socrata/cetera/metrics/BalboaClient.scala
+++ b/src/main/scala/com/socrata/cetera/metrics/BalboaClient.scala
@@ -1,0 +1,18 @@
+package com.socrata.cetera.metrics
+
+import java.io.File
+
+import com.blist.metrics.impl.queue.MetricFileQueue
+import com.socrata.metrics.{QueryString, DomainId}
+import org.slf4j.LoggerFactory
+
+class BalboaClient(dataDirectory: String) {
+
+  private val queue = MetricFileQueue.getInstance(new File(dataDirectory))
+  lazy val logger = LoggerFactory.getLogger(classOf[BalboaClient])
+
+  def logQuery(domainId: Int, query: String): Unit = {
+    logger info s"Logging query '$query' to balboa"
+    queue.logDatasetSearch(DomainId(domainId), QueryString(query))
+  }
+}

--- a/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -12,6 +12,7 @@ import com.socrata.cetera._
 case class Domain(isCustomerDomain: Boolean,
                   organization: Option[String],
                   domainCname: String,
+                  domainId: Int,
                   siteTitle: Option[String],
                   moderationEnabled: Boolean,
                   routingApprovalEnabled: Boolean)

--- a/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -15,7 +15,8 @@ import org.elasticsearch.action.search.SearchResponse
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.search.{DocumentClient, DomainClient}
+import com.socrata.cetera.metrics.BalboaClient
+import com.socrata.cetera.search.{DocumentClient, Domain, DomainClient}
 import com.socrata.cetera.types._
 import com.socrata.cetera.util.JsonResponses._
 import com.socrata.cetera.util._
@@ -41,7 +42,9 @@ object SearchResult {
   implicit val jCodec = AutomaticJsonCodecBuilder[SearchResult]
 }
 
-class SearchService(elasticSearchClient: DocumentClient, domainClient: DomainClient) extends SimpleResource {
+class SearchService(elasticSearchClient: DocumentClient,
+                    domainClient: DomainClient,
+                    balboaClient: BalboaClient) extends SimpleResource {
   lazy val logger = LoggerFactory.getLogger(classOf[SearchService])
 
   // TODO: cetera-etl rename customer_blah to domain_blah
@@ -129,6 +132,16 @@ class SearchService(elasticSearchClient: DocumentClient, domainClient: DomainCli
     })
   }
 
+  def logSearchTerm(domain: Option[Domain], query: QueryType): Unit = {
+    domain.foreach(d =>
+      query match {
+        case NoQuery => // nothing to log to balboa
+        case SimpleQuery(q) => balboaClient.logQuery(d.domainId, q)
+        case AdvancedQuery(q) => balboaClient.logQuery(d.domainId, q)
+      }
+    )
+  }
+
   def doSearch(queryParameters: MultiQueryParams): (SearchResults[SearchResult], InternalTimings) = {
     val now = Timings.now()
     QueryParametersParser(queryParameters) match {
@@ -155,6 +168,9 @@ class SearchService(elasticSearchClient: DocumentClient, domainClient: DomainCli
         ).execute.actionGet
 
         val timings = InternalTimings(Timings.elapsedInMillis(now), Option(res.getTookInMillis))
+
+        logSearchTerm(domain, params.searchQuery)
+
         val count = res.getHits.getTotalHits
         val formattedResults: SearchResults[SearchResult] = format(params.showScore, res)
           .copy(resultSetSize = Some(count), timings = Some(timings))

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -705,7 +705,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
   "applyMinShouldMatch" should {
     val msm = Some("2<-25% 9<-3") // I can be an involved string
-    val sc = Domain(false, None, "example.com", Some("Example! (dotcom)"), false, false)
+    val sc = Domain(false, None, "example.com", 1, Some("Example! (dotcom)"), false, false)
 
     "apply minShouldMatch if present" in {
       documentClient.applyMinShouldMatch(msm, None) should be (msm)

--- a/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
@@ -21,6 +21,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers  with TestESData wit
         isCustomerDomain = true,
         organization = Some(""),
         domainCname = "petercetera.net",
+        domainId = 0,
         siteTitle = Some("Temporary URI"),
         moderationEnabled = false,
         routingApprovalEnabled = true)

--- a/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
@@ -97,6 +97,7 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
         isCustomerDomain = false,
         organization = Some("SDP"),
         domainCname = "peterschneider.net",
+        domainId = 1,
         siteTitle = Some("Temporary URI"),
         moderationEnabled = false,
         routingApprovalEnabled = true

--- a/src/test/scala/com/socrata/cetera/search/TestESData.scala
+++ b/src/test/scala/com/socrata/cetera/search/TestESData.scala
@@ -84,6 +84,7 @@ trait TestESData {
   val esDomainTemplate: String =
     """{
       | "domain_cname": %s,
+      | "domain_id": %s,
       | "site_title": %s,
       | "organization": %s,
       | "is_customer_domain": %s,
@@ -105,7 +106,7 @@ trait TestESData {
                          socrataIdDatasetId: String,
                          socrataIdDomainCnames: Seq[String],
                          siteTitle: String,
-                         domainId: Seq[Long],
+                         domainId: Int,
                          resourceDescription: String,
                          resourceNbeFxf: String,
                          resourceUpdatedAt: String,
@@ -138,7 +139,7 @@ trait TestESData {
       quoteQualify(socrataIdDatasetId),
       quoteQualify(socrataIdDomainCnames),
       quoteQualify(siteTitle),
-      domainId.mkString(",\n"),
+      domainId.toString,
       quoteQualify(resourceDescription),
       quoteQualify(resourceNbeFxf),
       quoteQualify(resourceUpdatedAt),
@@ -167,9 +168,9 @@ trait TestESData {
     doc
   }
 
-  private def buildEsDomain(domainCname: String, siteTitle: String, organization: String,
+  private def buildEsDomain(domainCname: String, domainId: Int, siteTitle: String, organization: String,
                             isCustomerDomain: Boolean, moderationEnabled: Boolean, routingApprovalEnabled: Boolean) =
-    esDomainTemplate.format(quoteQualify(domainCname), quoteQualify(siteTitle), quoteQualify(organization),
+    esDomainTemplate.format(quoteQualify(domainCname), domainId.toString, quoteQualify(siteTitle), quoteQualify(organization),
                             isCustomerDomain.toString, moderationEnabled.toString, routingApprovalEnabled.toString)
 
   private def buildEsDocByIndex(i: Int): String = {
@@ -178,7 +179,7 @@ trait TestESData {
       socrataIdDatasetIds(i % socrataIdDatasetIds.length),
       socrataIdDomainCnames(i % socrataIdDomainCnames.length),
       siteTitles(i % siteTitles.length),
-      domainIds(i % domainIds.length),
+      i,
       resourceDescriptions(i % resourceDescriptions.length),
       resourceNbeFxfs(i % resourceNbeFxfs.length),
       defaultResourceUpdatedAt,
@@ -207,6 +208,7 @@ trait TestESData {
 
   private def buildEsDomainByIndex(cname:String, i: Int): String = {
     buildEsDomain(cname,
+                  i,
                   siteTitles(i % siteTitles.length),
                   defaultSocrataIdOrg,
                   isCustomerDomains(i % isCustomerDomains.length),
@@ -226,7 +228,6 @@ trait TestESData {
   val socrataIdDomainCnames = Seq("petercetera.net", "opendata-demo.socrata.com", "blue.org").map(Seq(_))
   val domainCnames = Seq("petercetera.net", "opendata-demo.socrata.com", "blue.org", "annabelle.island.net")
   val siteTitles = Seq("Temporary URI", "And other things", "Fame and Fortune", "Socrata Demo")
-  val domainIds = Seq(1L, 2L, 3L).map(Seq(_))
   val numericIds = 0 to Datatypes.materialized.length
   val socrataIdDatasetIds = numericIds.map(n => s"fxf-$n")
   val resourceDescriptions = Seq(

--- a/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
@@ -1,6 +1,7 @@
 package com.socrata.cetera.services
 
 import com.rojoma.json.v3.ast.{JNumber, JString}
+import com.socrata.cetera.metrics.BalboaClient
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
 
 import com.socrata.cetera.search._
@@ -14,7 +15,8 @@ class DatatypeBoostSpec extends FunSuiteLike with Matchers with TestESData with 
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
   val documentClient: DocumentClient = new DocumentClient(client, datatypeBoosts, None, None, Set.empty)
   val domainClient: DomainClient = new DomainClient(client)
-  val service: SearchService = new SearchService(documentClient, domainClient)
+  val balboaClient: BalboaClient = new BalboaClient("/tmp/metrics")
+  val service: SearchService = new SearchService(documentClient, domainClient, balboaClient)
 
   override protected def beforeAll(): Unit = {
     bootstrapData()


### PR DESCRIPTION
#### What it do?

The description sums it up well, but here are the details:

- Add a BalboaClient using the File-based queue (it's this or the NoopQueue)
- Add the corresponding config (everywhere .. in configs, for docker, in reference.conf)
- Add a method to the SearchService to log the message if we have a domain and a query with some text. 
- Add and patch tests (more on that below)
- Changed the resolver names to something more semantic


#### How was it tested?

##### New tests:

This turned out to be a bit of a pain, but because the balboaClient uses a file based queue, the only way I could figure to test this is to have a test write out to a bullshit directory and check the contents.  And of course, to ensure the tests are running in a clean env, delete the directory and it's contents before and after the test.  This seems a little risky deleting a directory, but wasn't sure else how to test.

##### Old tests:

Rather than keep around a "domain_ids" in the TestESData, I changed things to just use the iterator counter, since it's already an int.  

##### Running in staging: 

This change IS in staging (on the one instance that is actually running). I searched for "kaiyan" on disco-cheetah1.test-socrata.com and you can see that the search is picked up by the admin page now at https://disco-cheetah1.test-socrata.com/admin/analytics

#### Notes

1. Katie has already run etl, so the changes there are no worry.
2. There is an apps-marathon change that needs to accompany this though. I'll push that shortly.
3. Staging is sort of foo-barred right now with one of our instances in a broken-limbo state.