### PR TITLE
Jason/en 1183/domain boosting

### DIFF
--- a/src/main/scala/com/socrata/cetera/search/Boosts.scala
+++ b/src/main/scala/com/socrata/cetera/search/Boosts.scala
@@ -5,17 +5,27 @@ import org.elasticsearch.index.query.{BoolQueryBuilder, QueryBuilders}
 import com.socrata.cetera.types.{Datatype, DatatypeFieldType, DomainFieldType}
 
 object Boosts {
-  def boostDomains(domainBoosts: Map[String, Float]): BoolQueryBuilder = {
-    domainBoosts.foldLeft(QueryBuilders.boolQuery()) {
-      case (q, (domain, boost)) =>
-        q.should(QueryBuilders.termQuery(DomainFieldType.fieldName, domain).boost(boost))
+  def boostDatatypes(
+      query: BoolQueryBuilder,
+      datatypeBoosts: Map[Datatype, Float])
+    : BoolQueryBuilder = {
+
+    datatypeBoosts.foldLeft(query) {
+      case (q, (datatype, boost)) => q
+        .should(QueryBuilders.termQuery(DatatypeFieldType.fieldName, datatype.singular)
+        .boost(boost))
     }
   }
 
-  def boostDatatypes(typeBoosts: Map[Datatype, Float]): BoolQueryBuilder = {
-    typeBoosts.foldLeft(QueryBuilders.boolQuery()) {
-      case (q, (datatype, boost)) =>
-        q.should(QueryBuilders.termQuery(DatatypeFieldType.fieldName, datatype.singular).boost(boost))
+  def boostDomains(
+      query: BoolQueryBuilder,
+      domainBoosts: Map[String, Float])
+    : BoolQueryBuilder = {
+
+    domainBoosts.foldLeft(query) {
+      case (q, (domain, boost)) => q
+        .should(QueryBuilders.termQuery(DomainFieldType.rawFieldName, domain)
+        .boost(boost))
     }
   }
 }

--- a/src/main/scala/com/socrata/cetera/search/Boosts.scala
+++ b/src/main/scala/com/socrata/cetera/search/Boosts.scala
@@ -1,0 +1,21 @@
+package com.socrata.cetera.search
+
+import org.elasticsearch.index.query.{BoolQueryBuilder, QueryBuilders}
+
+import com.socrata.cetera.types.{Datatype, DatatypeFieldType, DomainFieldType}
+
+object Boosts {
+  def boostDomains(domainBoosts: Map[String, Float]): BoolQueryBuilder = {
+    domainBoosts.foldLeft(QueryBuilders.boolQuery()) {
+      case (q, (domain, boost)) =>
+        q.should(QueryBuilders.termQuery(DomainFieldType.fieldName, domain).boost(boost))
+    }
+  }
+
+  def boostDatatypes(typeBoosts: Map[Datatype, Float]): BoolQueryBuilder = {
+    typeBoosts.foldLeft(QueryBuilders.boolQuery()) {
+      case (q, (datatype, boost)) =>
+        q.should(QueryBuilders.termQuery(DatatypeFieldType.fieldName, datatype.singular).boost(boost))
+    }
+  }
+}

--- a/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -218,6 +218,7 @@ class DocumentClient(
       only: Option[Seq[String]],
       fieldBoosts: Map[CeteraFieldType with Boostable, Float],
       datatypeBoosts: Map[Datatype, Float],
+      domainBoosts: Map[String, Float],
       minShouldMatch: Option[String],
       slop: Option[Int])
     : SearchRequestBuilder = {
@@ -269,6 +270,7 @@ class DocumentClient(
       only: Option[Seq[String]],
       fieldBoosts: Map[CeteraFieldType with Boostable, Float],
       datatypeBoosts: Map[Datatype, Float],
+      domainBoosts: Map[String, Float],
       minShouldMatch: Option[String],
       slop: Option[Int],
       offset: Int,
@@ -278,8 +280,22 @@ class DocumentClient(
 
     val sort = Sorts.chooseSort(searchQuery, searchContext, categories, tags)
 
-    buildBaseRequest(searchQuery, domains, searchContext, categories, tags, domainMetadata,
-                     only, fieldBoosts, datatypeBoosts, minShouldMatch, slop)
+    val baseRequest = buildBaseRequest(
+      searchQuery,
+      domains,
+      searchContext,
+      categories,
+      tags,
+      domainMetadata,
+      only,
+      fieldBoosts,
+      datatypeBoosts,
+      domainBoosts,
+      minShouldMatch,
+      slop
+    )
+
+    baseRequest
       .setFrom(offset)
       .setSize(limit)
       .addSort(sort)
@@ -297,8 +313,22 @@ class DocumentClient(
 
     val aggregation = Aggregations.chooseAggregation(field)
 
-    buildBaseRequest(searchQuery, domains, searchContext, categories, tags,
-                     None, only, Map.empty, Map.empty, None, None)
+    val baseRequest = buildBaseRequest(
+      searchQuery,
+      domains,
+      searchContext,
+      categories,
+      tags,
+      None,
+      only,
+      Map.empty,
+      Map.empty,
+      Map.empty,
+      None,
+      None
+    )
+
+    baseRequest
       .addAggregation(aggregation)
       .setSearchType("count")
   }

--- a/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -7,7 +7,7 @@ import com.socrata.cetera.types._
 object Filters {
   def datatypeFilter(datatypes: Option[Seq[String]]): Option[TermsFilterBuilder] =
     datatypes.map { ts =>
-      val validatedDatatypes = ts.map(t => Datatype(t).map(_.singular)).flatten
+      val validatedDatatypes = ts.flatMap(t => Datatype(t).map(_.singular))
       FilterBuilders.termsFilter(DatatypeFieldType.fieldName, validatedDatatypes: _*)
     }
 

--- a/src/main/scala/com/socrata/cetera/search/Sorts.scala
+++ b/src/main/scala/com/socrata/cetera/search/Sorts.scala
@@ -44,13 +44,9 @@ object Sorts {
       tags: Option[Set[String]])
     : SortBuilder = {
 
-    (searchQuery, categories, tags) match {
-      // Query
-      case (AdvancedQuery(_) | SimpleQuery(_), _, _) => Sorts.sortScoreDesc
-
+    (searchQuery, searchContext, categories, tags) match {
       // ODN Categories
-      // Q: What happens when we search according to domain_categories? It's not clear
-      case (_, Some(cats), _) if searchContext.isEmpty =>
+      case (NoQuery, None, Some(cats), _) =>
         buildAverageScoreSort(
           CategoriesFieldType.Score.fieldName,
           CategoriesFieldType.Name.rawFieldName,
@@ -58,17 +54,15 @@ object Sorts {
         )
 
       // ODN Tags
-      case (_, _, Some(ts)) if searchContext.isEmpty =>
+      case (NoQuery, None, None, Some(ts)) =>
         buildAverageScoreSort(
           TagsFieldType.Score.fieldName,
           TagsFieldType.Name.rawFieldName,
           ts
         )
 
-      // Default (No query, categories, or tags)
-      case (_, _, _) =>
-        Sorts.sortFieldDesc(PageViewsTotalFieldType.fieldName)
+      // Everything else
+      case _ => Sorts.sortScoreDesc
     }
   }
-
 }

--- a/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
+++ b/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
@@ -1,9 +1,9 @@
 package com.socrata.cetera.search
 
+import org.elasticsearch.index.query.{MultiMatchQueryBuilder, QueryBuilders}
 import org.elasticsearch.index.query.functionscore.{FunctionScoreQueryBuilder, ScoreFunctionBuilders}
-import org.elasticsearch.index.query.{BoolQueryBuilder, MultiMatchQueryBuilder, QueryBuilders}
 
-import com.socrata.cetera.types.{Datatype, DatatypeFieldType, ScriptScoreFunction}
+import com.socrata.cetera.types.ScriptScoreFunction
 
 object SundryBuilders {
   def addMinMatchConstraint(query: MultiMatchQueryBuilder, constraint: String): MultiMatchQueryBuilder =
@@ -19,12 +19,6 @@ object SundryBuilders {
 
     // Take a product of scores and replace original score with product
     query.scoreMode("multiply").boostMode("replace")
-  }
-
-  def boostTypes(typeBoosts: Map[Datatype, Float]): BoolQueryBuilder = {
-    typeBoosts.foldLeft(QueryBuilders.boolQuery()) { case (q, (datatype, boost)) =>
-      q.should(QueryBuilders.termQuery(DatatypeFieldType.fieldName, datatype.singular).boost(boost))
-    }
   }
 
   def multiMatch(q: String, mmType: MultiMatchQueryBuilder.Type): MultiMatchQueryBuilder =

--- a/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
+++ b/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
@@ -1,25 +1,12 @@
 package com.socrata.cetera.search
 
 import org.elasticsearch.index.query.{MultiMatchQueryBuilder, QueryBuilders}
-import org.elasticsearch.index.query.functionscore.{FunctionScoreQueryBuilder, ScoreFunctionBuilders}
-
-import com.socrata.cetera.types.ScriptScoreFunction
 
 object SundryBuilders {
   def addMinMatchConstraint(query: MultiMatchQueryBuilder, constraint: String): MultiMatchQueryBuilder =
     query.minimumShouldMatch(constraint)
 
   def addSlopParam(query: MultiMatchQueryBuilder, slop: Int): MultiMatchQueryBuilder = query.slop(slop)
-
-  def addFunctionScores(scriptScoreFunctions:Set[ScriptScoreFunction],
-                        query: FunctionScoreQueryBuilder): FunctionScoreQueryBuilder = {
-    scriptScoreFunctions.foreach { fn =>
-      query.add(ScoreFunctionBuilders.scriptFunction(fn.script, "expression"))
-    }
-
-    // Take a product of scores and replace original score with product
-    query.scoreMode("multiply").boostMode("replace")
-  }
 
   def multiMatch(q: String, mmType: MultiMatchQueryBuilder.Type): MultiMatchQueryBuilder =
     QueryBuilders.multiMatchQuery(q)

--- a/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -148,6 +148,7 @@ class SearchService(elasticSearchClient: DocumentClient, domainClient: DomainCli
           params.only,
           params.fieldBoosts,
           params.datatypeBoosts,
+          params.domainBoosts,
           params.minShouldMatch,
           params.slop,
           params.offset,

--- a/src/test/scala/com/socrata/cetera/search/BoostsSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/BoostsSpec.scala
@@ -3,12 +3,14 @@ package com.socrata.cetera.search
 import com.rojoma.json.v3.interpolation._
 import com.rojoma.json.v3.io.JsonReader
 import org.scalatest.{ShouldMatchers, WordSpec}
+import org.elasticsearch.index.query.{BoolQueryBuilder, QueryBuilders}
 
 import com.socrata.cetera.types.{Datatype, TypeDatalenses, TypeDatasets, TypeFilters}
 
 class BoostsSpec extends WordSpec with ShouldMatchers {
   "boostDatatypes" should {
     "add datatype boosts to the query" in {
+      val query = QueryBuilders.boolQuery()
       val datatypeBoosts = Map[Datatype, Float](
         TypeDatasets -> 1.23f,
         TypeDatalenses -> 2.34f,
@@ -25,16 +27,17 @@ class BoostsSpec extends WordSpec with ShouldMatchers {
         }
       }"""
 
-      val actual = Boosts.boostDatatypes(datatypeBoosts)
+      val actual = Boosts.boostDatatypes(query, datatypeBoosts)
       val actualJson = JsonReader.fromString(actual.toString)
 
       actualJson should be (expectedJson)
     }
 
     "return empty bool if called with empty map" in {
+      val query = QueryBuilders.boolQuery()
       val datatypeBoosts = Map.empty[Datatype, Float]
       val expectedJson = j"""{"bool" : { } }"""
-      val actual = Boosts.boostDatatypes(datatypeBoosts)
+      val actual = Boosts.boostDatatypes(query, datatypeBoosts)
       val actualJson = JsonReader.fromString(actual.toString)
       actualJson should be(expectedJson)
     }
@@ -42,6 +45,7 @@ class BoostsSpec extends WordSpec with ShouldMatchers {
 
   "boostDomains" should {
     "add domain cname boosts to the query" in {
+      val query = QueryBuilders.boolQuery()
       val domainBoosts = Map[String, Float](
         "example.com" -> 1.23f,
         "data.seattle.gov" -> 4.56f
@@ -50,22 +54,24 @@ class BoostsSpec extends WordSpec with ShouldMatchers {
       val expectedJson = j"""{
         "bool" : {
           "should" : [
-            { "term" : { "socrata_id.domain_cname" : { "value" : "example.com", "boost" : 1.23 } } },
-            { "term" : { "socrata_id.domain_cname" : { "value" : "data.seattle.gov", "boost" : 4.56 } } }
+            { "term" : { "socrata_id.domain_cname.raw" : { "value" : "example.com", "boost" : 1.23 } } },
+            { "term" : { "socrata_id.domain_cname.raw" : { "value" : "data.seattle.gov", "boost" : 4.56 } } }
           ]
         }
       }"""
 
-      val actual = Boosts.boostDomains(domainBoosts)
+      val actual = Boosts.boostDomains(query, domainBoosts)
       val actualJson = JsonReader.fromString(actual.toString)
 
       actualJson should be (expectedJson)
     }
 
     "return empty bool if called with empty map" in {
+      val query = QueryBuilders.boolQuery()
       val domainBoosts = Map.empty[String, Float]
       val expectedJson = j"""{"bool" : { } }"""
-      val actual = Boosts.boostDomains(domainBoosts)
+
+      val actual = Boosts.boostDomains(query, domainBoosts)
       val actualJson = JsonReader.fromString(actual.toString)
       actualJson should be(expectedJson)
     }

--- a/src/test/scala/com/socrata/cetera/search/BoostsSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/BoostsSpec.scala
@@ -1,0 +1,73 @@
+package com.socrata.cetera.search
+
+import com.rojoma.json.v3.interpolation._
+import com.rojoma.json.v3.io.JsonReader
+import org.scalatest.{ShouldMatchers, WordSpec}
+
+import com.socrata.cetera.types.{Datatype, TypeDatalenses, TypeDatasets, TypeFilters}
+
+class BoostsSpec extends WordSpec with ShouldMatchers {
+  "boostDatatypes" should {
+    "add datatype boosts to the query" in {
+      val datatypeBoosts = Map[Datatype, Float](
+        TypeDatasets -> 1.23f,
+        TypeDatalenses -> 2.34f,
+        TypeFilters -> 0.98f
+      )
+
+      val expectedJson = j"""{
+        "bool" : {
+          "should" : [
+            { "term" : { "datatype" : { "value" : "dataset", "boost" : 1.23 } } },
+            { "term" : { "datatype" : { "value" : "datalens", "boost" : 2.34 } } },
+            { "term" : { "datatype" : { "value" : "filter", "boost" : 0.98 } } }
+          ]
+        }
+      }"""
+
+      val actual = Boosts.boostDatatypes(datatypeBoosts)
+      val actualJson = JsonReader.fromString(actual.toString)
+
+      actualJson should be (expectedJson)
+    }
+
+    "return empty bool if called with empty map" in {
+      val datatypeBoosts = Map.empty[Datatype, Float]
+      val expectedJson = j"""{"bool" : { } }"""
+      val actual = Boosts.boostDatatypes(datatypeBoosts)
+      val actualJson = JsonReader.fromString(actual.toString)
+      actualJson should be(expectedJson)
+    }
+  }
+
+  "boostDomains" should {
+    "add domain cname boosts to the query" in {
+      val domainBoosts = Map[String, Float](
+        "example.com" -> 1.23f,
+        "data.seattle.gov" -> 4.56f
+        )
+
+      val expectedJson = j"""{
+        "bool" : {
+          "should" : [
+            { "term" : { "socrata_id.domain_cname" : { "value" : "example.com", "boost" : 1.23 } } },
+            { "term" : { "socrata_id.domain_cname" : { "value" : "data.seattle.gov", "boost" : 4.56 } } }
+          ]
+        }
+      }"""
+
+      val actual = Boosts.boostDomains(domainBoosts)
+      val actualJson = JsonReader.fromString(actual.toString)
+
+      actualJson should be (expectedJson)
+    }
+
+    "return empty bool if called with empty map" in {
+      val domainBoosts = Map.empty[String, Float]
+      val expectedJson = j"""{"bool" : { } }"""
+      val actual = Boosts.boostDomains(domainBoosts)
+      val actualJson = JsonReader.fromString(actual.toString)
+      actualJson should be(expectedJson)
+    }
+  }
+}

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -670,8 +670,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
                   "term" : { "datatype" : { "value" : "datalens", "boost" : 9.99 } }
                 },
                 {
-                  "term" :
-                    { "datatype" : { "value" : "datalens_map", "boost" : 10.1 } }
+                  "term" : { "datatype" : { "value" : "datalens_map", "boost" : 10.1 } }
                 }
               ]
           }
@@ -681,7 +680,6 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         "query string OR (query AND string)",
         Map(DescriptionFieldType -> 7.77f, TitleFieldType -> 8.88f), // test field boosts
         Map(TypeDatalenses -> 9.99f, TypeDatalensMaps -> 10.10f), // test type boosts
-        Map.empty[String, Float], // domain boosts are empty for now
         Some("20%"), // minShouldMatch is a String because it can be a percentage
         Some(12) // slop is max num of intervening unmatched positions permitted
       )
@@ -692,26 +690,26 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     }
   }
 
-  //////////////////////
-  // applyMinShouldMatch
-  //////////////////////
+  ///////////////////////
+  // chooseMinShouldMatch
+  ///////////////////////
 
-  "applyMinShouldMatch" should {
+  "chooseMinShouldMatch" should {
     val msm = Some("2<-25% 9<-3") // I can be an involved string
     val sc = Domain(false, None, "example.com", Some("Example! (dotcom)"), false, false)
 
-    "apply minShouldMatch if present" in {
-      documentClient.applyMinShouldMatch(msm, None) should be (msm)
-      documentClient.applyMinShouldMatch(msm, Some(sc)) should be (msm)
+    "choose minShouldMatch if present" in {
+      documentClient.chooseMinShouldMatch(msm, None) should be (msm)
+      documentClient.chooseMinShouldMatch(msm, Some(sc)) should be (msm)
     }
 
     // Use case here is increasing search precision on customer domains
-    "apply default MSM value if none is passed in but search context is present" in {
-      documentClient.applyMinShouldMatch(None, Some(sc)) should be (defaultMinShouldMatch)
+    "choose default MSM value if none is passed in but search context is present" in {
+      documentClient.chooseMinShouldMatch(None, Some(sc)) should be (defaultMinShouldMatch)
     }
 
-    "apply nothing if no MSM value is passed in and no search context is present" in {
-      documentClient.applyMinShouldMatch(None, None) should be (None)
+    "choose nothing if no MSM value is passed in and no search context is present" in {
+      documentClient.chooseMinShouldMatch(None, None) should be (None)
     }
   }
 }

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -669,6 +669,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         "query string OR (query AND string)",
         Map(DescriptionFieldType -> 7.77f, TitleFieldType -> 8.88f), // test field boosts
         Map(TypeDatalenses -> 9.99f, TypeDatalensMaps -> 10.10f), // test type boosts
+        Map.empty[String, Float], // domain boosts are empty for now
         Some("20%"), // minShouldMatch is a String because it can be a percentage
         Some(12) // slop is max num of intervening unmatched positions permitted
       )

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -43,6 +43,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
       DescriptionFieldType -> 1.1f
     ),
     datatypeBoosts = Map.empty,
+    domainBoosts = Map.empty[String, Float],
     minShouldMatch = None,
     slop = None,
     showScore = false,
@@ -232,6 +233,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         only = None,
         fieldBoosts = Map.empty,
         datatypeBoosts = Map.empty,
+        domainBoosts = Map.empty[String, Float],
         minShouldMatch = None,
         slop = None
       )
@@ -260,6 +262,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         only = None,
         fieldBoosts = Map.empty,
         datatypeBoosts = Map.empty,
+        domainBoosts = Map.empty[String, Float],
         minShouldMatch = None,
         slop = None
       )
@@ -289,6 +292,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         only = None,
         fieldBoosts = params.fieldBoosts,
         datatypeBoosts = Map.empty,
+        domainBoosts = Map.empty[String, Float],
         minShouldMatch = None,
         slop = None
       )
@@ -490,6 +494,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         only = params.only,
         fieldBoosts = Map.empty,
         datatypeBoosts = Map.empty,
+        domainBoosts = Map.empty[String, Float],
         minShouldMatch = None,
         slop = None,
         offset = params.offset,
@@ -543,6 +548,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         only = params.only,
         fieldBoosts = Map.empty,
         datatypeBoosts = Map.empty,
+        domainBoosts = Map.empty[String, Float],
         minShouldMatch = None,
         slop = None,
         offset = params.offset,

--- a/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
@@ -159,8 +159,8 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
       actual.toString should be(expectedAsString)
     }
 
-    "order by page views descending for default null query" in {
-      val expected = Sorts.sortFieldDesc("page_views.page_views_total")
+    "order by page score descending for default null query" in {
+      val expected = Sorts.sortScoreDesc
 
       val actual = Sorts.chooseSort(
         searchQuery = NoQuery,
@@ -169,7 +169,7 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
         tags = None
       )
 
-      actual.toString should be (expected.toString)
+      actual should be (expected)
     }
   }
 }

--- a/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
@@ -90,7 +90,7 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
       actual should be(expected)
     }
 
-    "order by query score desc when given a simple query" in {
+    "order by score desc when given a simple query" in {
       val expected = Sorts.sortScoreDesc
 
       val searchContext = Domain(
@@ -159,7 +159,7 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
       actual.toString should be(expectedAsString)
     }
 
-    "order by page score descending for default null query" in {
+    "order by score descending for default null query" in {
       val expected = Sorts.sortScoreDesc
 
       val actual = Sorts.chooseSort(

--- a/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
@@ -1,0 +1,87 @@
+package com.socrata.cetera.services
+
+import com.rojoma.json.v3.ast.{JNumber, JString}
+import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+
+import com.socrata.cetera.search._
+import com.socrata.cetera.types._
+import com.socrata.cetera.util.Params
+
+class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
+  val boostedDatatype = TypeCharts
+  val datatypeBoosts =  Map[Datatype, Float](boostedDatatype -> 10F)
+
+  val client: ElasticSearchClient = new TestESClient(testSuiteName)
+  val documentClient: DocumentClient = new DocumentClient(client, datatypeBoosts, None, None, Set.empty)
+  val domainClient: DomainClient = new DomainClient(client)
+  val service: SearchService = new SearchService(documentClient, domainClient)
+
+  override protected def beforeAll(): Unit = {
+    bootstrapData()
+  }
+
+  override protected def afterAll(): Unit = {
+    removeBootstrapData()
+    client.close()
+  }
+
+  // blue.org and annabelle.island.net get filtered
+  val domain_cnames = Seq("petercetera.net", "opendata-demo.socrata.com")
+
+  test("domain boost of 2 should produce top result") {
+    domain_cnames.foreach { domain =>
+      val (results, _) = service.doSearch(Map(s"""boostDomains[${domain}]""" -> "2").mapValues(Seq(_)))
+      results.results.head.metadata("domain") should be(JString(domain))
+    }
+  }
+
+  test("domain boost of 0.5 should not produce top result") {
+    domain_cnames.foreach { domain =>
+      val (results, _) = service.doSearch(Map(s"""boostDomains[${domain}]""" -> "0.5").mapValues(Seq(_)))
+      results.results.head.metadata("domain") shouldNot be(JString(domain))
+    }
+  }
+
+  test("domain boosts are not mistaken for custom metadata") {
+    domain_cnames.foreach { domain =>
+      val (results, _) = service.doSearch(
+        Map(s"""boostDomains[${domain}]""" -> "2.34",
+            "boostDomains[]" -> "3.45", // if I were custom metadata, I would not match any documents
+            Params.context -> domain).mapValues(Seq(_))
+      )
+      results.results.size should be > 0
+    }
+  }
+
+  // just documenting behavior; this may not be ideal behavior
+  test("boostDomains with no [] is treated as custom metadata") {
+    domain_cnames.foreach { domain =>
+      val (results, _) = service.doSearch(
+        Map(s"""boostDomains[${domain}]""" -> "2.34",
+            "boostDomains" -> "3.45", // interpreted as custom metadata field which doesn't match any documents
+            Params.context -> domain).mapValues(Seq(_))
+      )
+      results.results.size should be(0)
+    }
+  }
+
+  test("datatype boost - increases score when datatype matches") {
+    val (results, _) = service.doSearch(Map(
+      Params.querySimple -> "best",
+      Params.showScore -> "true"
+    ).mapValues(Seq(_)))
+    val oneBoosted = results.results.find(_.resource.dyn.`type`.! == JString(boostedDatatype.singular)).head
+    val oneOtherThing = results.results.find(_.resource.dyn.`type`.! != JString(boostedDatatype.singular)).head
+
+    val datalensScore: Float = oneBoosted.metadata("score") match {
+      case n: JNumber => n.toFloat
+      case _ => fail()
+    }
+    val otherScore: Float = oneOtherThing.metadata("score") match {
+      case n: JNumber => n.toFloat
+      case _ => fail()
+    }
+
+    datalensScore should be > otherScore
+  }
+}

--- a/src/test/scala/com/socrata/cetera/types/QueryTypeSpec.scala
+++ b/src/test/scala/com/socrata/cetera/types/QueryTypeSpec.scala
@@ -1,0 +1,71 @@
+package com.socrata.cetera.types
+
+import org.scalatest.{ShouldMatchers, WordSpec}
+
+class QueryTypeSpec extends WordSpec with ShouldMatchers {
+  "minShouldMatch" should {
+    "return None from a NoQuery" in {
+      val query = NoQuery
+      val msm = MinShouldMatch.fromParam(query, "3")
+      msm should be(None)
+    }
+
+    "return None from an AdvancedQuery" in {
+      val query = AdvancedQuery("anything goes here")
+      val msm = MinShouldMatch.fromParam(query, "75%")
+      msm should be(None)
+    }
+
+    "return Some from a SimpleQuery" in {
+      val query = SimpleQuery("data about dancing shoes")
+      val msm = MinShouldMatch.fromParam(query, "3<90%")
+      msm should be(Some("3<90%"))
+    }
+
+    "trim whitespace from param" in {
+      val query = SimpleQuery("pasta and other cards")
+      val msm = MinShouldMatch.fromParam(query, " 2<-25%  9<-3   ")
+      msm should be(Some("2<-25%  9<-3"))
+    }
+  }
+
+  "getScriptFunction" should {
+    "not have a view (singular) script" in {
+      val script = ScriptScoreFunction.getScriptFunction("view")
+      script match {
+        case Some(_) => fail("view (singular) script should not exist")
+        case None =>
+      }
+    }
+
+    "have a views (plural) script" in {
+      val script = ScriptScoreFunction.getScriptFunction("views")
+      script match {
+        case Some(_) =>
+        case None => fail("expected to find a views script")
+      }
+    }
+
+    "have a score (singular) script" in {
+      val script = ScriptScoreFunction.getScriptFunction("score")
+      script match {
+        case Some(_) =>
+        case None => fail("expected to find a score (singular) script")
+      }
+    }
+
+    "not have a scores (plural) script" in {
+      val script = ScriptScoreFunction.getScriptFunction("scores")
+      script match {
+        case Some(_) => fail("scores (plural) script should not exist")
+        case None =>
+      }
+    }
+  }
+
+  "domainBoostsScoreFunction" should {
+    "return an empty set when given an empty set" in {
+      val domainBoosts = Map.empty[String, Float]
+    }
+  }
+}

--- a/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
+++ b/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
@@ -263,7 +263,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
     }
   }
 
-  test("domain boost defined twice will go with the first definition -- just documenting behavior") {
+  test("domain boost defined twice will be completely ignored -- just documenting behavior") {
     val domainBoosts = Map(
       "boostDomains[example.com]" -> Seq("1.23", "2.34"),
       "boostDomains[data.seattle.gov]" -> Seq("4.56")
@@ -271,7 +271,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
 
     QueryParametersParser(domainBoosts) match {
       case Right(params) =>
-        params.domainBoosts should be(Map("example.com" -> 1.23f, "data.seattle.gov" -> 4.56f))
+        params.domainBoosts should be(Map("data.seattle.gov" -> 4.56f))
       case _ => fail()
     }
   }

--- a/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
+++ b/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
@@ -62,18 +62,24 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
         ColumnNameFieldType -> 10.0,
         ColumnDescriptionFieldType -> 10.0,
         ColumnFieldNameFieldType -> 10.0,
+
         TitleFieldType -> 9.0,
         DescriptionFieldType -> 8.0)
 
-    val vqps = qpp(Map("boostColumns" -> "10.0", "boostTitle" -> "9.0", "boostDesc" -> "8.0").mapValues(Seq(_)))
+    val vqps = qpp(
+      Map(
+        "boostColumns" -> "10.0", // should produce 3 boosts: name, description, field_name
+
+        "boostTitle" -> "9.0",
+        "boostDesc" -> "8.0"
+      ).mapValues(Seq(_)))
 
     vqps match {
       case Left(_) => fail("a ValidatedQueryParameters should be returned")
-      case Right(_) =>
+      case Right(params) =>
+        params.fieldBoosts should be (expectedFieldBoosts)
+        params.datatypeBoosts should be (Map())
     }
-
-    vqps.right.get.fieldBoosts should be (expectedFieldBoosts)
-    vqps.right.get.datatypeBoosts should be (Map())
   }
 
   test("datatype boosts are not treated as custom metadata key-value pairs") {
@@ -171,21 +177,25 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
   }
 
   test("domain metadata excludes known parameters") {
-    val knownEnumParams = Map("only" -> Seq("calendar",
-      "chart",
-      "datalens",
-      "dataset",
-      "file",
-      "filter",
-      "form",
-      "map",
-      "href",
-      "pulse",
-      "story",
-      "link",
-      "datalens_chart",
-      "datalens_map",
-      "tabular_map"))
+    val knownEnumParams = Map(
+      "only" -> Seq(
+        "calendar",
+        "chart",
+        "datalens",
+        "dataset",
+        "file",
+        "filter",
+        "form",
+        "map",
+        "href",
+        "pulse",
+        "story",
+        "link",
+        "datalens_chart",
+        "datalens_map",
+        "tabular_map"
+      )
+    )
 
     val knownNumericParams = List(
       "boostColumns",
@@ -215,9 +225,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
       "search_context",
       "domains",
       "categories",
-      "categories[]",
       "tags",
-      "tags[]",
       "q",
       "q_internal",
       "min_should_match",
@@ -226,10 +234,40 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
       "function_score"
     ).map(p => p -> Seq(p)).toMap
 
-    QueryParametersParser(knownEnumParams ++ knownNumericParams ++ knownStringParams) match {
+    val knownArrayParams = List(
+      "categories[]",
+      "tags[]"
+    ).map(p => p -> Seq(p)).toMap
+
+    // This is how they show up from socrata-http
+    val domainBoostExamples = List(
+      "boostDomains[example.com]",
+      "boostDomains[data.seattle.gov]",
+      "boostDomains[xyz]",
+      "boostDomains[]"
+    ).map(p => p -> Seq("1.23"))
+
+    QueryParametersParser(
+      knownEnumParams ++
+        knownNumericParams ++
+        knownStringParams ++
+        knownArrayParams ++
+        domainBoostExamples
+    ) match {
       case Right(params) =>
         params.domainMetadata shouldNot be('defined)
       case _ => fail()
+    }
+  }
+
+  // just documenting that we do not support boostDomains without the []
+  test ("boostDomains without [] gets interpreted as custom metadata") {
+    QueryParametersParser(Map("boostDomains" -> Seq("1.23"), "pants" -> Seq("2.34"))) match {
+      case Right(params) => params.domainMetadata match {
+        case Some(metadata) => metadata should be(Set("boostDomains" -> "1.23", "pants" -> "2.34"))
+        case None => fail("expected to see boostDomains show up in metadata")
+      }
+      case Left(e) => fail(e.toString)
     }
   }
 
@@ -256,8 +294,9 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
     )
 
     QueryParametersParser(domainBoosts) match {
-      case Right(params) =>
-        params.domainBoosts should be(Map("example.com" -> 1.23f, "data.seattle.gov" -> 4.56f))
+      case Right(params) => params.domainBoosts should be(
+        Map("example.com" -> 1.23f, "data.seattle.gov" -> 4.56f)
+      )
       case _ => fail()
     }
   }
@@ -269,8 +308,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
     )
 
     QueryParametersParser(domainBoosts) match {
-      case Right(params) =>
-        params.domainBoosts should be(Map("data.seattle.gov" -> 4.56f))
+      case Right(params) => params.domainBoosts should be(Map("data.seattle.gov" -> 4.56f))
       case _ => fail()
     }
   }
@@ -284,8 +322,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
     )
 
     QueryParametersParser(domainBoosts) match {
-      case Right(params) =>
-        params.domainBoosts should be(Map("data.seattle.gov" -> 4.56f))
+      case Right(params) => params.domainBoosts should be(Map("data.seattle.gov" -> 4.56f))
       case _ => fail()
     }
   }
@@ -296,9 +333,64 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
     )
 
     QueryParametersParser(domainBoosts) match {
-      case Right(params) =>
-        params.domainBoosts should be(Map("boostDomains[example.com]" -> 1.23f))
+      case Right(params) => params.domainBoosts should be(Map("boostDomains[example.com]" -> 1.23f))
       case _ => fail()
     }
+  }
+
+  test("domain boost params are not interpreted as custom metadata fields") {
+    val params = Map(
+      Params.context -> Seq("example.com"),
+      Params.boostDomains + "[example.com]" -> Seq("1.23")
+    )
+
+    QueryParametersParser(params) match {
+      case Right(p) => p.domainBoosts should be(Map("example.com" -> 1.23f))
+      case _ => fail()
+    }
+  }
+
+  // just documenting current if not-quite-ideal behavior
+  test("boostDomains without [] is not supported and gets interpreted as metadata") {
+    val params = Map(
+      Params.context -> Seq("example.com"),
+      Params.boostDomains + "example.com" -> Seq("1.23"),
+      Params.boostDomains -> Seq("1.23")
+    )
+
+    QueryParametersParser(params) match {
+      case Right(p) => p.domainBoosts should be(Map.empty[String, Float])
+      case _ => fail()
+    }
+  }
+}
+
+class ParamsSpec extends FunSuiteLike with Matchers {
+  test("isCatalogKey can recognize string keys") {
+    val keys = Seq("search_context", "only", "domains", "slop", "boostMaps")
+    keys.foreach { key =>
+      Params.isCatalogKey(key) should be (true)
+      Params.isCatalogKey(key.reverse) should be (false)
+     }
+  }
+
+  test("isCatalogKey can recognize array keys") {
+    val keys = Seq("categories[]", "tags[]")
+    keys.foreach { key =>
+      Params.isCatalogKey(key) should be (true)
+      Params.isCatalogKey("phony_" + key) should be (false)
+    }
+  }
+
+  test("isCatalogKey can recognize hashmap keys like boostDomains[]") {
+    val keys = Seq("boostDomains[example.com]", "boostDomains[data.seattle.gov]")
+    keys.foreach { key =>
+      Params.isCatalogKey(key) should be (true)
+      Params.isCatalogKey("phony_" + key) should be (false)
+    }
+  }
+
+  test("isCatalogKey does not recognize boostDomains without []") {
+    Params.isCatalogKey("boostDomains") should be (false)
   }
 }

--- a/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
+++ b/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
@@ -241,7 +241,6 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
     }
   }
 
-  // Q: what happens on &one+extra= ?
   // empty query string param is passed in from socrata-http multi params sometimes, e.g. catalog?q=bikes&one+extra
   test("handle empty query string param value") {
     QueryParametersParser(Map("one extra" -> Seq())) match {


### PR DESCRIPTION
This branch wraps every base request up in a Function Score Query and will pass along any domain-level boosts directly to that function score.

There are three function scores which come into play:
* "score" is the query score is (1.0 for all if no search query is present)
* "views" is (1.0 + log(page_views_total + 1.0)) or something like that.
* a domainBoosts score which is the value passed into domainBoosts[example.com]=1.23

"score" * "views" * "boosts" => final score

These scores are multiplied together at the end, after all the normalizations and everything else happens. Thus, a domainBoost of 0.8 will lower a domain's scores across the board by 0.8.

The one exception to this rule is that *sort* will override the function score! Thus, in the case of ODN categories and tags, the confidence scores that these labels got will trump. When other sort orders are added, these will also trump the function score.

There is further clean up and reorganization work for later commits, but I would like to get this merged now because the fundamental change to the query structure is best merged before further development takes place.
