### PR TITLE
Remove default datatype boosting

### DIFF
--- a/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -60,7 +60,6 @@ object SearchServer extends App {
 
     val documentClient = DocumentClient(
       esClient,
-      config.elasticSearch.typeBoosts.getOrElse(Map.empty),
       config.elasticSearch.titleBoost,
       config.elasticSearch.minShouldMatch,
       config.elasticSearch.functionScoreScripts.flatMap(fnName =>

--- a/src/main/scala/com/socrata/cetera/config/AppConfig.scala
+++ b/src/main/scala/com/socrata/cetera/config/AppConfig.scala
@@ -46,6 +46,5 @@ class ElasticSearchConfig(config:Config, root:String) extends ConfigClass(config
   val titleBoost = optionally[Float](config.getDouble(path("title-boost")).toFloat)
   val minShouldMatch = optionally[String](getString("min-should-match"))
   val functionScoreScripts = getStringList("function-score-scripts")
-  val typeBoosts = optionally[Map[String, Float]](getObjectOf[Float]("type-boosts", getBoostMap))
 }
 // $COVERAGE-ON$

--- a/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -10,19 +10,13 @@ import com.socrata.cetera.types._
 object DocumentClient {
   def apply(
       esClient: ElasticSearchClient,
-      defaultTypeBoosts: Map[String, Float],
       defaultTitleBoost: Option[Float],
       defaultMinShouldMatch: Option[String],
       scriptScoreFunctions: Set[ScriptScoreFunction])
     : DocumentClient = {
 
-    val datatypeBoosts = defaultTypeBoosts.flatMap { case (k, v) =>
-      Datatype(k).map(datatype => (datatype, v))
-    }
-
     new DocumentClient(
       esClient,
-      datatypeBoosts,
       defaultTitleBoost,
       defaultMinShouldMatch,
       scriptScoreFunctions
@@ -32,7 +26,6 @@ object DocumentClient {
 
 class DocumentClient(
     esClient: ElasticSearchClient,
-    defaultTypeBoosts: Map[Datatype, Float],
     defaultTitleBoost: Option[Float],
     defaultMinShouldMatch: Option[String],
     scriptScoreFunctions: Set[ScriptScoreFunction]) {
@@ -167,10 +160,6 @@ class DocumentClient(
       .getOrElse(fieldBoosts)
   }
 
-  private def applyDefaultDatatypeBoosts(datatypeBoosts: Map[Datatype, Float]) = {
-    defaultTypeBoosts ++ datatypeBoosts
-  }
-
   def chooseMinShouldMatch(
       minShouldMatch: Option[String],
       searchContext: Option[Domain])
@@ -217,7 +206,7 @@ class DocumentClient(
       case AdvancedQuery(queryString) => generateAdvancedQuery(queryString, fieldBoosts)
       case SimpleQuery(queryString) => generateSimpleQuery(queryString,
         applyDefaultTitleBoost(fieldBoosts),
-        applyDefaultDatatypeBoosts(datatypeBoosts),
+        datatypeBoosts,
         chooseMinShouldMatch(minShouldMatch, searchContext),
         slop)
     }

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -32,7 +32,6 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
   val documentClient: DocumentClient = DocumentClient(
     esClient = client,
-    defaultTypeBoosts = Map.empty,
     defaultTitleBoost = None,
     defaultMinShouldMatch = defaultMinShouldMatch,
     scriptScoreFunctions = scriptScoreFunctions

--- a/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
@@ -11,7 +11,7 @@ import com.socrata.cetera.util.SearchResults
 
 class CountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAll {
   val client: ElasticSearchClient = new TestESClient("CountService")
-  val documentClient: DocumentClient = DocumentClient(client, Map.empty, None, None, Set.empty)
+  val documentClient: DocumentClient = DocumentClient(client, None, None, Set.empty)
   val domainClient: DomainClient = new DomainClient(client)
   val service: CountService = new CountService(documentClient, domainClient)
 

--- a/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
@@ -10,10 +10,9 @@ import com.socrata.cetera.util.Params
 
 class DatatypeBoostSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
   val boostedDatatype = TypeCharts
-  val datatypeBoosts =  Map[Datatype, Float](boostedDatatype -> 10F)
 
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
-  val documentClient: DocumentClient = new DocumentClient(client, datatypeBoosts, None, None, Set.empty)
+  val documentClient: DocumentClient = new DocumentClient(client, None, None, Set.empty)
   val domainClient: DomainClient = new DomainClient(client)
   val balboaClient: BalboaClient = new BalboaClient("/tmp/metrics")
   val service: SearchService = new SearchService(documentClient, domainClient, balboaClient)
@@ -30,7 +29,8 @@ class DatatypeBoostSpec extends FunSuiteLike with Matchers with TestESData with 
   test("datatype boost - increases score when datatype matches") {
     val (results, _) = service.doSearch(Map(
       Params.querySimple -> "best",
-      Params.showScore -> "true"
+      Params.showScore -> "true",
+      "boostCharts" -> "10"
     ).mapValues(Seq(_)))
     val oneBoosted = results.results.find(_.resource.dyn.`type`.! == JString(boostedDatatype.singular)).head
     val oneOtherThing = results.results.find(_.resource.dyn.`type`.! != JString(boostedDatatype.singular)).head

--- a/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
@@ -10,10 +10,9 @@ import com.socrata.cetera.util.Params
 
 class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
   val boostedDatatype = TypeCharts
-  val datatypeBoosts =  Map[Datatype, Float](boostedDatatype -> 10F)
 
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
-  val documentClient: DocumentClient = new DocumentClient(client, datatypeBoosts, None, None, Set.empty)
+  val documentClient: DocumentClient = new DocumentClient(client, None, None, Set.empty)
   val domainClient: DomainClient = new DomainClient(client)
   val balboaClient: BalboaClient = new BalboaClient("/tmp/metrics")
   val service: SearchService = new SearchService(documentClient, domainClient, balboaClient)
@@ -70,7 +69,8 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
   test("datatype boost - increases score when datatype matches") {
     val (results, _) = service.doSearch(Map(
       Params.querySimple -> "best",
-      Params.showScore -> "true"
+      Params.showScore -> "true",
+      "boostCharts" -> "10"
     ).mapValues(Seq(_)))
     val oneBoosted = results.results.find(_.resource.dyn.`type`.! == JString(boostedDatatype.singular)).head
     val oneOtherThing = results.results.find(_.resource.dyn.`type`.! != JString(boostedDatatype.singular)).head

--- a/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
@@ -7,7 +7,7 @@ import com.socrata.cetera.types.Datatypes
 
 class FacetServiceSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
-  val documentClient: DocumentClient = DocumentClient(client, Map.empty, None, None, Set.empty)
+  val documentClient: DocumentClient = DocumentClient(client, None, None, Set.empty)
   val domainClient: DomainClient = new DomainClient(client)
   val service: FacetService = new FacetService(documentClient)
 

--- a/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -24,7 +24,7 @@ import com.socrata.cetera.types._
 
 class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAll {
   val client: ElasticSearchClient = new TestESClient("SearchService")
-  val documentClient: DocumentClient = DocumentClient(client, Map.empty, None, None, Set.empty)
+  val documentClient: DocumentClient = DocumentClient(client, None, None, Set.empty)
   val domainClient: DomainClient = new DomainClient(client)
   val balboaClient: BalboaClient = new BalboaClient("/tmp/metrics")
   val service: SearchService = new SearchService(documentClient, domainClient, balboaClient)
@@ -210,7 +210,7 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
 
 class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
-  val documentClient: DocumentClient = DocumentClient(client, Map.empty, None, None, Set.empty)
+  val documentClient: DocumentClient = DocumentClient(client, None, None, Set.empty)
   val domainClient: DomainClient = new DomainClient(client)
   val balboaDir: java.io.File = new java.io.File("balboa_test_trash")
   val balboaClient: BalboaClient = new BalboaClient(balboaDir.getName)


### PR DESCRIPTION
Datatype boosting must come through query params now
`type-boosts` in the config no longer does anything

Just some house-keeping before spiking on sorts.