### PR TITLE
Jason/en 1919/add sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ Examples (running locally):
 
 See the [Apiary API spec](http://docs.cetera.apiary.io/#) for more detail.
 
-Any other url gives an error message.
-
-
 # Elasticsearch setup
 
 Cetera, in development use, assumes an ElasticSearch setup as follows:

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,9 @@ fullClasspath in Test <+= baseDirectory map { d => Attributed.blank(d / "configs
 
 de.johoop.jacoco4sbt.JacocoPlugin.jacoco.settings
 
+// Disable code uglifier
+com.socrata.sbtplugins.StylePlugin.StyleKeys.styleFailOnError in Compile := false
+
 initialize := {
   val jvRequired = "1.8"
   val jvCurrent = sys.props("java.specification.version")

--- a/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -268,7 +268,11 @@ class DocumentClient(
     )
 
     // WARN: Sort will totally blow away score if score isn't part of the sort
-    val sort = Sorts.chooseSort(searchQuery, searchContext, categories, tags)
+    // "Relevance" without a query can mean different things, so chooseSort decides
+    val sort = sortOrder match {
+      case Some(so) if so != "relevance" => Sorts.paramSortMap.get(so).get // will raise if invalid param got through
+      case _ => Sorts.chooseSort(searchQuery, searchContext, categories, tags)
+    }
 
     baseRequest
       .setFrom(offset)

--- a/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -248,8 +248,7 @@ class DocumentClient(
       minShouldMatch: Option[String],
       slop: Option[Int],
       offset: Int,
-      limit: Int,
-      advancedQuery: Option[String] = None)
+      limit: Int)
     : SearchRequestBuilder = {
 
     val baseRequest = buildBaseRequest(

--- a/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -248,7 +248,8 @@ class DocumentClient(
       minShouldMatch: Option[String],
       slop: Option[Int],
       offset: Int,
-      limit: Int)
+      limit: Int,
+      sortOrder: Option[String])
     : SearchRequestBuilder = {
 
     val baseRequest = buildBaseRequest(

--- a/src/main/scala/com/socrata/cetera/search/Sorts.scala
+++ b/src/main/scala/com/socrata/cetera/search/Sorts.scala
@@ -36,6 +36,16 @@ object Sorts {
       )
   }
 
+  // Map of param to sorts on ES fields
+  val paramSortMap = Map[String, SortBuilder](
+    "relevance" -> sortScoreDesc,
+    "page_views_last_week" -> sortFieldDesc("page_views_last_week"),
+    "page_views_last_month" -> sortFieldDesc("page_views_last_month"),
+    "page_views_last_year" -> sortFieldDesc("page_views_last_year"),
+    "created_at" -> sortFieldDesc("created_at"),
+    "updated_at" -> sortFieldDesc("updatedAt")
+  )
+
   // First pass logic is very simple. query >> categories >> tags >> default
   def chooseSort(
       searchQuery: QueryType,

--- a/src/main/scala/com/socrata/cetera/search/Sorts.scala
+++ b/src/main/scala/com/socrata/cetera/search/Sorts.scala
@@ -5,6 +5,7 @@ import org.elasticsearch.search.sort.{FieldSortBuilder, SortBuilder, SortBuilder
 
 import com.socrata.cetera.types._
 
+// TODO: Ultimately, these should accept Sortables rather than Strings
 object Sorts {
   val sortScoreDesc: SortBuilder = {
     SortBuilders.scoreSort().order(SortOrder.DESC)
@@ -37,13 +38,38 @@ object Sorts {
   }
 
   // Map of param to sorts on ES fields
+  // These sorts are tentative and will not be documented in apiary until finalized
   val paramSortMap = Map[String, SortBuilder](
+    // Default
+    // Due to current logic in DocumentClient, this is used only as a key--its value is not returned from here.
     "relevance" -> sortScoreDesc,
-    "page_views_last_week" -> sortFieldDesc("page_views_last_week"),
-    "page_views_last_month" -> sortFieldDesc("page_views_last_month"),
-    "page_views_last_year" -> sortFieldDesc("page_views_last_year"),
-    "created_at" -> sortFieldDesc("created_at"),
-    "updated_at" -> sortFieldDesc("updatedAt")
+
+    // Timestamps
+    "createdAt ASC" -> sortFieldAsc(CreatedAtFieldType.fieldName),
+    "createdAt DESC" -> sortFieldDesc(CreatedAtFieldType.fieldName),
+    "createdAt" -> sortFieldDesc(CreatedAtFieldType.fieldName),
+
+    "updatedAt ASC" -> sortFieldAsc(UpdatedAtFieldType.fieldName),
+    "updatedAt DESC" -> sortFieldDesc(UpdatedAtFieldType.fieldName),
+    "updatedAt" -> sortFieldDesc(UpdatedAtFieldType.fieldName),
+
+    // Page views
+    "page_views_last_week ASC" -> sortFieldAsc(PageViewsLastWeekFieldType.fieldName),
+    "page_views_last_week DESC" -> sortFieldDesc(PageViewsLastWeekFieldType.fieldName),
+    "page_views_last_week" -> sortFieldDesc(PageViewsLastWeekFieldType.fieldName),
+
+    "page_views_last_month ASC" -> sortFieldAsc(PageViewsLastMonthFieldType.fieldName),
+    "page_views_last_month DESC" -> sortFieldDesc(PageViewsLastMonthFieldType.fieldName),
+    "page_views_last_month" -> sortFieldDesc(PageViewsLastMonthFieldType.fieldName),
+
+    "page_views_total ASC" -> sortFieldAsc(PageViewsTotalFieldType.fieldName),
+    "page_views_total DESC" -> sortFieldDesc(PageViewsTotalFieldType.fieldName),
+    "page_views_total" -> sortFieldDesc(PageViewsTotalFieldType.fieldName),
+
+    // Alphabetical
+    "name" -> sortFieldAsc(NameFieldType.fieldName),
+    "name ASC" -> sortFieldAsc(NameFieldType.fieldName),
+    "name DESC" -> sortFieldDesc(NameFieldType.fieldName)
   )
 
   // First pass logic is very simple. query >> categories >> tags >> default

--- a/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -173,7 +173,8 @@ class SearchService(elasticSearchClient: DocumentClient,
           params.minShouldMatch,
           params.slop,
           params.offset,
-          params.limit
+          params.limit,
+          params.sortOrder
         )
 
         logESRequest(req)

--- a/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -145,7 +145,7 @@ case object DomainMetadataFieldType extends Mapable with Rawable {
 /////////////
 // Boostables
 
-case object TitleFieldType extends Boostable with Rawable with Sortable {
+case object TitleFieldType extends Boostable with Rawable {
   val fieldName: String = "indexed_metadata.name"
 }
 

--- a/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -15,6 +15,9 @@ sealed trait Boostable extends CeteraFieldType
 // A field that we allow to be be counted (e.g., how many documents of a given tag do we have?)
 sealed trait Countable extends CeteraFieldType
 
+// A field that we allow to be sorted on
+sealed trait Sortable extends CeteraFieldType
+
 // Used for nested fields like arrays or json blobs
 sealed trait NestedField extends CeteraFieldType {
   protected val path: String
@@ -142,7 +145,7 @@ case object DomainMetadataFieldType extends Mapable with Rawable {
 /////////////
 // Boostables
 
-case object TitleFieldType extends Boostable with Rawable {
+case object TitleFieldType extends Boostable with Rawable with Sortable {
   val fieldName: String = "indexed_metadata.name"
 }
 
@@ -170,7 +173,19 @@ case object DatatypeFieldType extends Boostable {
 //////////////
 // For sorting
 
-case object PageViewsTotalFieldType extends CeteraFieldType {
+// most accessed
+case object PageViewsTotalFieldType extends CeteraFieldType with Sortable {
   val fieldName: String = "page_views.page_views_total"
 }
 
+// recently updated
+// (not currently returned in payload to end user, probably should be)
+case object UpdatedAtFieldType extends CeteraFieldType with Sortable {
+  val fieldName: String = "updatedAt"
+}
+
+// frequently updated
+// (not currently returned in payload to end user, probably should be)
+case object UpdateFrequencyFieldType extends CeteraFieldType with Sortable {
+  val fieldName: String = "update_freq"
+}

--- a/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -173,19 +173,26 @@ case object DatatypeFieldType extends Boostable {
 //////////////
 // For sorting
 
-// most accessed
 case object PageViewsTotalFieldType extends CeteraFieldType with Sortable {
   val fieldName: String = "page_views.page_views_total"
 }
 
-// recently updated
-// (not currently returned in payload to end user, probably should be)
-case object UpdatedAtFieldType extends CeteraFieldType with Sortable {
-  val fieldName: String = "updatedAt"
+case object PageViewsLastMonthFieldType extends CeteraFieldType with Sortable {
+  val fieldName: String = "page_views.page_views_last_month"
 }
 
-// frequently updated
-// (not currently returned in payload to end user, probably should be)
-case object UpdateFrequencyFieldType extends CeteraFieldType with Sortable {
-  val fieldName: String = "update_freq"
+case object PageViewsLastWeekFieldType extends CeteraFieldType with Sortable {
+  val fieldName: String = "page_views.page_views_last_week"
+}
+
+case object UpdatedAtFieldType extends CeteraFieldType with Sortable {
+  val fieldName: String = "updated_at" // notice the snake_case, long story
+}
+
+case object CreatedAtFieldType extends CeteraFieldType with Sortable {
+  val fieldName: String = "created_at" // notice the snake_case, long story
+}
+
+case object NameFieldType extends CeteraFieldType with Sortable {
+  val fieldName: String = "indexed_metadata.name.raw"
 }

--- a/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
+++ b/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
@@ -4,34 +4,39 @@ import com.socrata.http.server.HttpRequest
 
 import com.socrata.cetera.types._
 
+// These are validated input parameters but aren't supposed to know anything about ES
 case class ValidatedQueryParameters(
-  searchQuery: QueryType,
-  domains: Set[String],
-  domainMetadata: Option[Set[(String, String)]],
-  searchContext: Option[String],
-  categories: Option[Set[String]],
-  tags: Option[Set[String]],
-  only: Option[Seq[String]],
-  fieldBoosts: Map[CeteraFieldType with Boostable, Float],
-  datatypeBoosts: Map[Datatype, Float],
-  domainBoosts: Map[String, Float],
-  minShouldMatch: Option[String],
-  slop: Option[Int],
-  showScore: Boolean,
-  offset: Int,
-  limit: Int
+    searchQuery: QueryType,
+    domains: Set[String],
+    domainMetadata: Option[Set[(String, String)]],
+    searchContext: Option[String],
+    categories: Option[Set[String]],
+    tags: Option[Set[String]],
+    only: Option[Seq[String]],
+    fieldBoosts: Map[CeteraFieldType with Boostable, Float],
+    datatypeBoosts: Map[Datatype, Float],
+    domainBoosts: Map[String, Float],
+    minShouldMatch: Option[String],
+    slop: Option[Int],
+    showScore: Boolean,
+    offset: Int,
+    limit: Int,
+    sortOrder: Option[String]
 )
 
+// NOTE: this is really a validation error, not a parse error
 sealed trait ParseError { def message: String }
 
-case class OnlyError(override val message: String) extends ParseError
 case class LimitError(override val message: String) extends ParseError
+case class OffsetError(override val message: String) extends ParseError
+case class OnlyError(override val message: String) extends ParseError
+case class SortOrderError(override val message: String) extends ParseError
 
 // Parses and validates
 object QueryParametersParser {
   val defaultPageOffset: Int = 0
   val defaultPageLength: Int = 100
-  val filterDelimiter: String = ","
+  val filterDelimiter: String = "," // to be deprecated
 
   def validated[T](x: Either[ParamConversionFailure, T]): T = x match {
     case Right(v) => v
@@ -44,17 +49,32 @@ object QueryParametersParser {
     if (a >= 0) Some(NonNegativeInt(a)) else None
   }
 
-  // for boost
+  // for boosts
   case class NonNegativeFloat(value: Float)
   implicit val nonNegativeFloatParamConverter = ParamConverter.filtered { (a: Float) =>
     if (a >= 0.0f) Some(NonNegativeFloat(a)) else None
   }
 
+  // for sort order
+  case class SortOrderString(value: String)
+  implicit val sortOrderStringParamConverter = ParamConverter.filtered { (a: String) =>
+    if (allowedSortOrders.contains(a)) Some(SortOrderString(a)) else None
+  }
+
+  private val allowedSortOrders = Set[String](
+    "relevance",
+    "page_views_last_month",
+    "page_views_last_week",
+    "page_views_total",
+    "created_at",
+    "updated_at"
+  )
+
   // If both are specified, prefer the advanced query over the search query
-  private def pickQuery(simple: Option[String], advanced: Option[String]): QueryType =
-    (simple, advanced) match {
-      case (_, Some(aq)) => AdvancedQuery(aq)
-      case (Some(sq), _) => SimpleQuery(sq)
+  private def pickQuery(advanced: Option[String], simple: Option[String]): QueryType =
+    (advanced, simple) match {
+      case (Some(aq), _) => AdvancedQuery(aq)
+      case (_, Some(sq)) => SimpleQuery(sq)
       case _ => NoQuery
     }
 
@@ -63,24 +83,67 @@ object QueryParametersParser {
     if (cs.nonEmpty) Some(cs) else None
   }
 
+  // Used to support param=this,that and param[]something&param[]=more
   private def mergeParams(queryParameters: MultiQueryParams,
                           selectKeys: Set[String],
                           transform: String => String = identity): Option[Set[String]] =
     mergeOptionalSets(selectKeys.map(key => queryParameters.get(key).map(_.map(value => transform(value)).toSet)))
 
-  val allowedTypes = Datatypes.all.flatMap(d => Seq(d.plural, d.singular)).mkString(",")
+  val allowedFilterTypes = Datatypes.all.flatMap(d => Seq(d.plural, d.singular)).mkString(",")
 
   // This can stay case-sensitive because it is so specific
   def restrictParamFilterType(only: Option[String]): Either[OnlyError, Option[Seq[String]]] =
     only.map { s =>
       Datatype(s) match {
-        case None => Left(OnlyError(s"'only' must be one of $allowedTypes; got $s"))
+        case None => Left(OnlyError(s"'only' must be one of $allowedFilterTypes; got $s"))
         case Some(d) => Right(Some(d.names))
       }
     }.getOrElse(Right(None))
 
   def apply(req: HttpRequest): Either[Seq[ParseError], ValidatedQueryParameters] =
     apply(req.multiQueryParams)
+
+
+  //////////////////
+  // PARAM PREPARERS
+  //
+  // Prepare means parse and validate
+
+  def prepareSearchQuery(queryParameters: MultiQueryParams) = {
+    pickQuery(
+      queryParameters.get(Params.queryAdvanced).flatMap(_.headOption),
+      queryParameters.get(Params.querySimple).flatMap(_.headOption)
+    )
+  }
+
+  def prepareDomains(queryParameters: MultiQueryParams): Set[String] = {
+    queryParameters.first(Params.filterDomains) match {
+      case Some(ds) => ds.toLowerCase.split(filterDelimiter).toSet
+      case None => Set.empty[String]
+    }
+  }
+
+  def prepareSearchContext(queryParameters: MultiQueryParams) = {
+    queryParameters.first(Params.context).map(_.toLowerCase)
+  }
+
+  def prepareCategories(queryParameters: MultiQueryParams) = {
+    mergeParams(queryParameters, Set(Params.filterCategories, Params.filterCategoriesArray))
+  }
+
+  def prepareTags(queryParameters: MultiQueryParams) = {
+    mergeParams(queryParameters, Set(Params.filterTags, Params.filterTagsArray))
+  }
+
+  def prepareOnly(queryParameters: MultiQueryParams) = {
+    restrictParamFilterType(queryParameters.first(Params.filterType))
+  }
+
+  def prepareDomainMetadata(queryParameters: MultiQueryParams): Option[Set[(String, String)]] = {
+    val queryParamsNonEmpty = queryParameters.filter { case (key, value) => key.nonEmpty && value.nonEmpty }
+    val ms = Params.remaining(queryParamsNonEmpty).mapValues(_.head).toSet
+    if (ms.nonEmpty) Some(ms) else None
+  }
 
   def prepareFieldBoosts(queryParameters: MultiQueryParams): Map[CeteraFieldType with Boostable, Float] = {
     val boostTitle = queryParameters.typedFirst[NonNegativeFloat](Params.boostTitle).map(validated(_).value)
@@ -101,12 +164,52 @@ object QueryParametersParser {
       .toMap[CeteraFieldType with Boostable, Float]
   }
 
+  def prepareDatatypeBoosts(queryParameters: MultiQueryParams): Map[Datatype, Float] = {
+    queryParameters.flatMap {
+      case (k, _) => Params.datatypeBoostParam(k).flatMap(datatype =>
+        queryParameters.typedFirst[NonNegativeFloat](k).map(boost =>
+          (datatype, validated(boost).value)))
+    }
+  }
+
   def prepareDomainBoosts(queryParameters: MultiQueryParams): Map[String, Float] = {
     val domainExtractor = new FieldExtractor(Params.boostDomains)
     queryParameters.collect { case (domainExtractor(field), Seq(FloatExtractor(weight))) =>
       field -> weight
     }
   }
+
+  // Yes we compute searchQuery twice because this is a smell
+  def prepareMinShouldMatch(queryParameters: MultiQueryParams) = {
+    val searchQuery = prepareSearchQuery(queryParameters)
+    queryParameters.first(Params.minMatch).flatMap { p =>
+      MinShouldMatch.fromParam(searchQuery, p)
+    }
+  }
+
+  def prepareSlop(queryParameters: MultiQueryParams) = {
+    queryParameters.typedFirst[Int](Params.slop).map(validated)
+  }
+
+  def prepareShowScore(queryParameters: MultiQueryParams) = {
+    queryParameters.contains(Params.showScore)
+  }
+
+  def prepareOffset(queryParameters: MultiQueryParams) = {
+    validated(
+      queryParameters.typedFirstOrElse(Params.scanOffset, NonNegativeInt(defaultPageOffset))
+    ).value
+  }
+
+  def prepareLimit(queryParameters: MultiQueryParams) = {
+    validated(
+      queryParameters.typedFirstOrElse(Params.scanLength, NonNegativeInt(defaultPageLength))
+    ).value
+  }
+
+  //
+  //////////////////
+
 
   // for extracting `example.com` from `boostDomains[example.com]`
   class FieldExtractor(val key: String) {
@@ -121,57 +224,68 @@ object QueryParametersParser {
       catch { case _: NumberFormatException => None }
   }
 
+  def prepareSortOrder(queryParameters: MultiQueryParams): Option[String] = {
+    queryParameters.typedFirst[SortOrderString](Params.sortOrder).map(validated(_).value)
+  }
+
+  ////////
+  // APPLY
+  //
   // NOTE: Watch out for case sensitivity in params
   // Some field values are stored internally in lowercase, others are not
   // Yes, the params parser now concerns itself with ES internals
   def apply(queryParameters: MultiQueryParams): Either[Seq[ParseError], ValidatedQueryParameters] = {
-    val query = pickQuery(
-      queryParameters.get(Params.querySimple).flatMap(_.headOption),
-      queryParameters.get(Params.queryAdvanced).flatMap(_.headOption)
-    )
 
-    val domains: Set[String] = queryParameters.first(Params.filterDomains) match {
-      case Some(ds) => ds.toLowerCase.split(filterDelimiter).toSet
-      case None => Set.empty[String]
-    }
+    // NOTE! We don't have to run most of these if just any of them fail validation
+
+    val searchQuery = prepareSearchQuery(queryParameters)
+    val domains = prepareDomains(queryParameters)
+    val domainMetadata = prepareDomainMetadata(queryParameters)
+    val searchContext = prepareSearchContext(queryParameters)
+    val categories = prepareCategories(queryParameters)
+    val tags = prepareTags(queryParameters)
+
+    val only = prepareOnly(queryParameters)
 
     val fieldBoosts = prepareFieldBoosts(queryParameters)
-
-    val datatypeBoosts = queryParameters.flatMap {
-      case (k, _) => Params.datatypeBoostParam(k).flatMap(datatype =>
-        queryParameters.typedFirst[NonNegativeFloat](k).map(boost =>
-          (datatype, validated(boost).value)))
-    }
-
+    val datatypeBoosts = prepareDatatypeBoosts(queryParameters)
     val domainBoosts = prepareDomainBoosts(queryParameters)
+    val minShouldMatch = prepareMinShouldMatch(queryParameters)
 
-    restrictParamFilterType(queryParameters.first(Params.filterType)) match {
+    val slop = prepareSlop(queryParameters)
+    val showScore = prepareShowScore(queryParameters)
+
+    val offset = prepareOffset(queryParameters)
+    val limit = prepareLimit(queryParameters)
+
+    val sortOrder = prepareSortOrder(queryParameters)
+
+    // TODO reorder semantically (searchContext before domainMetadata)
+    // Add params to the match to provide helpful error messages
+    only match {
       case Right(o) =>
-        Right(ValidatedQueryParameters(
-          query,
+        Right(
+          ValidatedQueryParameters(
+          searchQuery,
           domains,
-          queryStringDomainMetadata(queryParameters),
-          queryParameters.first(Params.context).map(_.toLowerCase),
-          mergeParams(queryParameters, Set(Params.filterCategories, Params.filterCategoriesArray)),
-          mergeParams(queryParameters, Set(Params.filterTags, Params.filterTagsArray)),
+          domainMetadata,
+          searchContext,
+          categories,
+          tags,
           o,
           fieldBoosts,
           datatypeBoosts,
           domainBoosts,
-          queryParameters.first(Params.minMatch).flatMap { p => MinShouldMatch.fromParam(query, p) },
-          queryParameters.typedFirst[Int](Params.slop).map(validated), // Check for slop
-          queryParameters.contains(Params.showScore), // just a flag
-          validated(queryParameters.typedFirstOrElse(Params.scanOffset, NonNegativeInt(defaultPageOffset))).value,
-          validated(queryParameters.typedFirstOrElse(Params.scanLength, NonNegativeInt(defaultPageLength))).value
-        ))
+          minShouldMatch,
+          slop,
+          showScore,
+          offset,
+          limit,
+          sortOrder
+          )
+        )
       case Left(e) => Left(Seq(e))
     }
-  }
-
-  private def queryStringDomainMetadata(queryParameters: MultiQueryParams): Option[Set[(String, String)]] = {
-    val queryParamsNonEmpty = queryParameters.filter { case (key, value) => key.nonEmpty && value.nonEmpty }
-    val ms = Params.remaining(queryParamsNonEmpty).mapValues(_.head).toSet
-    if (ms.nonEmpty) Some(ms) else None
   }
 }
 
@@ -237,6 +351,7 @@ object Params {
 
   val scanLength = "limit"
   val scanOffset = "offset"
+  val sortOrder = "order"
 
 
   ///////////////////////
@@ -264,7 +379,8 @@ object Params {
     showScore,
     functionScore,
     scanLength,
-    scanOffset
+    scanOffset,
+    sortOrder
   ) ++ datatypeBoostParams.toSet
 
   // If your param is an array like tags[]=fun&tags[]=ice+cream

--- a/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
+++ b/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
@@ -28,10 +28,7 @@ case class ValidatedQueryParameters(
 // NOTE: this is really a validation error, not a parse error
 sealed trait ParseError { def message: String }
 
-case class LimitError(override val message: String) extends ParseError
-case class OffsetError(override val message: String) extends ParseError
 case class OnlyError(override val message: String) extends ParseError
-case class SortOrderError(override val message: String) extends ParseError
 
 // Parses and validates
 object QueryParametersParser {
@@ -107,9 +104,8 @@ object QueryParametersParser {
       catch { case _: NumberFormatException => None }
   }
 
-  def prepareSortOrder(queryParameters: MultiQueryParams): Option[String] = {
+  def prepareSortOrder(queryParameters: MultiQueryParams): Option[String] =
     queryParameters.typedFirst[SortOrderString](Params.sortOrder).map(validated(_).value)
-  }
 
   def apply(req: HttpRequest): Either[Seq[ParseError], ValidatedQueryParameters] =
     apply(req.multiQueryParams)

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -59,7 +59,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     slop = None,
     showScore = false,
     offset = 10,
-    limit = 20
+    limit = 20,
+    sortOrder = None
   )
 
   val shouldMatch = j"""{

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -570,7 +570,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         minShouldMatch = None,
         slop = None,
         offset = params.offset,
-        limit = params.limit
+        limit = params.limit,
+        sortOrder = params.sortOrder
       )
 
       val actual = JsonReader.fromString(request.toString)
@@ -624,7 +625,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         minShouldMatch = None,
         slop = None,
         offset = params.offset,
-        limit = params.limit
+        limit = params.limit,
+        sortOrder = params.sortOrder
       )
 
       val actual = JsonReader.fromString(request.toString)

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -60,7 +60,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     showScore = false,
     offset = 10,
     limit = 20,
-    sortOrder = None
+    sortOrder = Option("relevance") // should be the same as None
   )
 
   val shouldMatch = j"""{

--- a/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
@@ -173,4 +173,43 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
       actual should be (expected)
     }
   }
+
+  "Sorts.paramSortMap" should {
+    val order_asc = "\"order\" : \"asc\""
+    val order_desc = "\"order\" : \"desc\""
+
+    def testSortOrder(keys: Iterable[String], order: String): Unit = {
+      keys.foreach { key =>
+        Sorts.paramSortMap.get(key) match {
+          case Some(sort) => sort.toString should include (order)
+          case None => fail(s"missing sort order key: ${key}")
+        }
+      }
+    }
+
+    "explicit ascending sorts are all ascending" in {
+      val ascending_sort_keys = Sorts.paramSortMap.keys.filter { k => k.endsWith("ASC") }
+      testSortOrder(ascending_sort_keys, order_asc)
+    }
+
+    "explicit descending sorts are all descending" in {
+      val descending_sort_keys = Sorts.paramSortMap.keys.filter { k => k.endsWith("DESC") }
+      testSortOrder(descending_sort_keys,  order_desc)
+    }
+
+    "default ascending sorts are all ascending" in {
+      val default_ascending_sort_keys = Seq[String]("name")
+      testSortOrder(default_ascending_sort_keys, order_asc)
+    }
+
+    "default descending sorts are all descending" in {
+      val default_descending_sort_keys = Seq[String]("createdAt",
+        "updatedAt",
+        "page_views_last_week",
+        "page_views_last_month",
+        "page_views_total")
+
+      testSortOrder(default_descending_sort_keys, order_desc)
+    }
+  }
 }

--- a/src/test/scala/com/socrata/cetera/search/TestESData.scala
+++ b/src/test/scala/com/socrata/cetera/search/TestESData.scala
@@ -31,6 +31,7 @@ trait TestESData {
       |   "description": %s,
       |   "nbe_fxf": %s,
       |   "updatedAt": %s,
+      |   "createdAt": %s,
       |   "type": %s,
       |   "id": %s,
       |   "columns": {
@@ -110,6 +111,7 @@ trait TestESData {
                          resourceDescription: String,
                          resourceNbeFxf: String,
                          resourceUpdatedAt: String,
+                         resourceCreatedAt: String,
                          resourceId: String,
                          resourceColumns: Seq[String],
                          resourceName: String,
@@ -143,6 +145,7 @@ trait TestESData {
       quoteQualify(resourceDescription),
       quoteQualify(resourceNbeFxf),
       quoteQualify(resourceUpdatedAt),
+      quoteQualify(resourceCreatedAt),
       quoteQualify(datatype),
       quoteQualify(resourceId),
       quoteQualify(resourceColumns),
@@ -183,6 +186,7 @@ trait TestESData {
       resourceDescriptions(i % resourceDescriptions.length),
       resourceNbeFxfs(i % resourceNbeFxfs.length),
       defaultResourceUpdatedAt,
+      defaultResourceCreatedAt,
       resourceIds(i % resourceIds.length),
       defaultResourceColumns,
       resourceNames(i % resourceNames.length),
@@ -218,6 +222,7 @@ trait TestESData {
 
   val defaultSocrataIdOrg = ""
   val defaultResourceUpdatedAt = DateTime.now().toString
+  val defaultResourceCreatedAt = DateTime.now().toString
   val defaultResourceColumns = Nil
   val defaultAaCategories = Map("Personal" -> 1F)
   val defaultAaTags = Map("Happy" -> 0.65F, "Accident" -> 0.35F)

--- a/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
@@ -27,24 +27,24 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
   }
 
   // blue.org and annabelle.island.net get filtered
-  val domain_cnames = Seq("petercetera.net", "opendata-demo.socrata.com")
+  val activeDomainCnames = Seq("petercetera.net", "opendata-demo.socrata.com")
 
   test("domain boost of 2 should produce top result") {
-    domain_cnames.foreach { domain =>
+    activeDomainCnames.foreach { domain =>
       val (results, _) = service.doSearch(Map(s"""boostDomains[${domain}]""" -> "2").mapValues(Seq(_)))
       results.results.head.metadata("domain") should be(JString(domain))
     }
   }
 
   test("domain boost of 0.5 should not produce top result") {
-    domain_cnames.foreach { domain =>
+    activeDomainCnames.foreach { domain =>
       val (results, _) = service.doSearch(Map(s"""boostDomains[${domain}]""" -> "0.5").mapValues(Seq(_)))
       results.results.head.metadata("domain") shouldNot be(JString(domain))
     }
   }
 
   test("domain boosts are not mistaken for custom metadata") {
-    domain_cnames.foreach { domain =>
+    activeDomainCnames.foreach { domain =>
       val (results, _) = service.doSearch(
         Map(s"""boostDomains[${domain}]""" -> "2.34",
             "boostDomains[]" -> "3.45", // if I were custom metadata, I would not match any documents
@@ -56,7 +56,7 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
 
   // just documenting behavior; this may not be ideal behavior
   test("boostDomains with no [] is treated as custom metadata") {
-    domain_cnames.foreach { domain =>
+    activeDomainCnames.foreach { domain =>
       val (results, _) = service.doSearch(
         Map(s"""boostDomains[${domain}]""" -> "2.34",
             "boostDomains" -> "3.45", // interpreted as custom metadata field which doesn't match any documents

--- a/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -423,4 +423,22 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
     resultsTitleCase.results should contain theSameElementsAs resultsLowerCase.results
     resultsTitleCase.results should contain theSameElementsAs resultsUpperCase.results
   }
+
+  test("sorting by name works") {
+    val params = Map("order" -> Seq("name"))
+    val (results, _) = service.doSearch(params)
+    val firstResult = results.results.head.resource.dyn("name").? match {
+      case Right(n) => n should be (JString(resourceNames.sorted.head))
+      case Left(_) => fail("resource had no name!")
+    }
+  }
+
+  test("sorting by name DESC works") {
+    val params = Map("order" -> Seq("name DESC"))
+    val (results, _) = service.doSearch(params)
+    val firstResult = results.results.head.resource.dyn("name").? match {
+      case Right(n) => n should be (JString(resourceNames.sorted.last))
+      case Left(_) => fail("resource had no name!")
+    }
+  }
 }

--- a/src/test/scala/com/socrata/cetera/types/FieldTypesSpec.scala
+++ b/src/test/scala/com/socrata/cetera/types/FieldTypesSpec.scala
@@ -20,4 +20,15 @@ class FieldTypesSpec extends FunSuiteLike with Matchers {
 
     TitleFieldType.rawFieldName should be("indexed_metadata.name.raw")
   }
+
+  test("sortable field names are as expected") {
+    PageViewsTotalFieldType.fieldName should be ("page_views.page_views_total")
+    PageViewsLastMonthFieldType.fieldName should be ("page_views.page_views_last_month")
+    PageViewsLastWeekFieldType.fieldName should be ("page_views.page_views_last_week")
+
+    UpdatedAtFieldType.fieldName should be ("updated_at") // snake_case
+    CreatedAtFieldType.fieldName should be ("created_at") // snake_case
+
+    NameFieldType.fieldName should be ("indexed_metadata.name.raw")
+  }
 }

--- a/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
+++ b/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
@@ -372,6 +372,15 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
       case _ => fail()
     }
   }
+
+  test("sort order can be parsed") {
+    val sortOrder = Map("order" -> Seq("page_views_total"))
+
+    QueryParametersParser(sortOrder) match {
+      case Right(params) => params.sortOrder should be(Some("page_views_total"))
+      case _ => fail()
+    }
+  }
 }
 
 class ParamsSpec extends FunSuiteLike with Matchers {
@@ -401,5 +410,9 @@ class ParamsSpec extends FunSuiteLike with Matchers {
 
   test("isCatalogKey does not recognize boostDomains without []") {
     Params.isCatalogKey("boostDomains") should be (false)
+  }
+
+  test("isCatalogKey recognized sort order") {
+    Params.isCatalogKey("order") should be (true)
   }
 }

--- a/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
+++ b/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
@@ -194,6 +194,15 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
         "datalens_chart",
         "datalens_map",
         "tabular_map"
+      ),
+
+      "order" -> Seq(
+        "relevance",
+        "page_views_last_month",
+        "page_views_last_week",
+        "page_views_total",
+        "created_at",
+        "updated_at"
       )
     )
 


### PR DESCRIPTION
This enables sorting when the "order" param is passed in. Sorts.scala spells out exactly which fields may be sorted on and what their order keys are.