### PR TITLE
EN-3050 domain normalization

### DIFF
--- a/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -51,7 +51,7 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
 
       case Right(params) =>
         val domain = params.searchContext.flatMap(domainClient.find)
-        val res = documentClient.buildCountRequest(
+        val search = documentClient.buildCountRequest(
           field,
           params.searchQuery,
           params.domains,
@@ -59,7 +59,9 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
           params.categories,
           params.tags,
           params.only
-        ).execute.actionGet
+        )
+        logger.info(LogHelper.formatEsRequest(Indices, search))
+        val res = search.execute.actionGet
         val timings = InternalTimings(Timings.elapsedInMillis(now), Option(res.getTookInMillis))
         val json = JsonReader.fromString(res.toString)
         val counts = extract(json) match {

--- a/src/main/scala/com/socrata/cetera/services/FacetService.scala
+++ b/src/main/scala/com/socrata/cetera/services/FacetService.scala
@@ -50,6 +50,7 @@ class FacetService(documentClient: DocumentClient) {
     val startMs = Timings.now()
 
     val request = documentClient.buildFacetRequest(cname)
+    logger.info(LogHelper.formatEsRequest(Indices, request))
     val res = request.execute().actionGet()
     val aggs = res.getAggregations.asMap().asScala
       .getOrElse("domain_filter", throw new NoSuchElementException).asInstanceOf[Filter]

--- a/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -132,14 +132,6 @@ class SearchService(elasticSearchClient: DocumentClient,
     })
   }
 
-  private def logESRequest(search: SearchRequestBuilder): Unit =
-    logger.info(
-      s"""Elasticsearch request
-         | indices: ${Indices.mkString(",")},
-         | body: ${search.toString.replaceAll("""[\n\s]+""", " ")}
-       """.stripMargin
-    )
-
   def logSearchTerm(domain: Option[Domain], query: QueryType): Unit = {
     domain.foreach(d =>
       query match {
@@ -177,7 +169,7 @@ class SearchService(elasticSearchClient: DocumentClient,
           params.sortOrder
         )
 
-        logESRequest(req)
+        logger.info(LogHelper.formatEsRequest(Indices, req))
 
         val res = req.execute.actionGet
 

--- a/src/main/scala/com/socrata/cetera/util/LogHelper.scala
+++ b/src/main/scala/com/socrata/cetera/util/LogHelper.scala
@@ -1,6 +1,7 @@
 package com.socrata.cetera.util
 
 import com.socrata.http.server.HttpRequest
+import org.elasticsearch.action.search.SearchRequestBuilder
 
 object LogHelper {
   // WARN: changing this will likely break Sumo (regex-based log parser)
@@ -13,5 +14,11 @@ object LogHelper {
       request.servletRequest.getRemoteHost,
       s"""TIMINGS ## ESTime : ${timings.searchMillis.getOrElse(-1)} ## ServiceTime : ${timings.serviceMillis}"""
     ).mkString(" -- ")
+  }
+
+  def formatEsRequest(indices: List[String], search: SearchRequestBuilder): String = {
+    s"""Elasticsearch request - indices: ${indices.mkString(",")},
+        | body: ${search.toString.replaceAll("""[\n\s]+""", " ")}
+     """.stripMargin.trim
   }
 }

--- a/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
@@ -2,7 +2,7 @@ package com.socrata.cetera.search
 
 import org.scalatest.{BeforeAndAfterAll, ShouldMatchers, WordSpec}
 
-class DomainClientSpec extends WordSpec with ShouldMatchers  with TestESData with BeforeAndAfterAll {
+class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData with BeforeAndAfterAll {
   val client = new TestESClient("domainClient")
   val domainClient: DomainClient = new DomainClient(client)
 
@@ -15,8 +15,8 @@ class DomainClientSpec extends WordSpec with ShouldMatchers  with TestESData wit
     client.close()
   }
 
-  "getDomain" should {
-    "return the right domain if it exists" in {
+  "find" should {
+    "return the domain if it exists : petercetera.net" in {
       val expectedDomain = Domain(
         isCustomerDomain = true,
         organization = Some(""),
@@ -26,14 +26,25 @@ class DomainClientSpec extends WordSpec with ShouldMatchers  with TestESData wit
         moderationEnabled = false,
         routingApprovalEnabled = true)
       val actualDomain = domainClient.find("petercetera.net")
+      actualDomain.get should be(expectedDomain)
+    }
 
+    "return the domain if it exists : opendata-demo.socrata.com" in {
+      val expectedDomain = Domain(
+        isCustomerDomain = true,
+        organization = Some(""),
+        domainCname = "opendata-demo.socrata.com",
+        domainId = 1,
+        siteTitle = Some("And other things"),
+        moderationEnabled = true,
+        routingApprovalEnabled = false)
+      val actualDomain = domainClient.find("opendata-demo.socrata.com")
       actualDomain.get should be(expectedDomain)
     }
 
     "return None if the domain does not exist" in {
       val expectedDomain = None
       val actualDomain = domainClient.find("hellcat.com")
-
       actualDomain should be(expectedDomain)
     }
   }

--- a/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
+++ b/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
@@ -62,7 +62,7 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
             "boostDomains" -> "3.45", // interpreted as custom metadata field which doesn't match any documents
             Params.context -> domain).mapValues(Seq(_))
       )
-      results.results.size should be(0)
+      results.results should contain theSameElementsAs List.empty
     }
   }
 


### PR DESCRIPTION
**what it do**
* lookup domain cname by match query instead of domain id, which will no longer be the primary key for this mapping type.
* validate domain client still works
* log other kinds of elaticsearch requests

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata/cetera/127)
<!-- Reviewable:end -->
