### PR TITLE
EN-3392 R&A filter term query

### DIFF
--- a/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -159,8 +159,7 @@ object Filters {
     val prefix = if (isDomainAgg) esDocumentType + "." else ""
     val domainId = prefix + SocrataIdDomainIdFieldType.fieldName
     val approvingDomainIds = prefix + ApprovingDomainIdsFieldType.fieldName
-    val documentIsApprovedByParentDomain =
-      scriptFilter(s"doc['$approvingDomainIds'].values.contains(doc['$domainId'].value)")
+    val documentIsApprovedByParentDomain = termFilter(prefix + "is_approved_by_parent_domain", true)
     val documentRAVisible = boolFilter()
       .should(parentDomainIsNotRA)
       .should(documentIsApprovedByParentDomain)

--- a/src/test/resources/base.json
+++ b/src/test/resources/base.json
@@ -17,6 +17,9 @@
         "approving_domain_ids" : {
           "type" : "long"
         },
+        "is_approved_by_parent_domain" : {
+          "type" : "boolean"
+        },
         "datatype" : {
           "type" : "string",
           "index": "not_analyzed"

--- a/src/test/scala/com/socrata/cetera/TestESClient.scala
+++ b/src/test/scala/com/socrata/cetera/TestESClient.scala
@@ -16,11 +16,6 @@ class TestESClient(val clusterName: String) extends ElasticSearchClient("local",
     .put("client.transport.sniff", false)
     .put("discovery.zen.ping.multicast.enabled", false)
     .put("path.data", tempDataDir.toString)
-    .put("script.groovy.sandbox.enabled", true)
-    .put("script.inline", true)
-    .put("script.indexed", true)
-    .put("script.file", true)
-    .put("script.search", true)
     .build
   val node = nodeBuilder().settings(testSettings).local(true).node()
 

--- a/src/test/scala/com/socrata/cetera/TestESData.scala
+++ b/src/test/scala/com/socrata/cetera/TestESData.scala
@@ -64,6 +64,7 @@ trait TestESData {
       | "approving_domain_ids": [
       |   %s
       | ],
+      | "is_approved_by_parent_domain": %s,
       | "page_views": {
       |   "page_views_total": %s
       | },
@@ -119,6 +120,7 @@ trait TestESData {
                          isDefaultView: Boolean,
                          isModerationApproved: Option[Boolean],
                          approvingDomainIds: Seq[Int],
+                         isApprovedByParentDomain: Boolean,
                          pageViewsTotal: String,
                          customerCategory: String,
                          customerTags: Seq[String],
@@ -148,6 +150,7 @@ trait TestESData {
       isDefaultView.toString,
       isModerationApproved.map(_.toString).getOrElse("null"),
       approvingDomainIds.mkString(","),
+      isApprovedByParentDomain.toString,
       pageViewsTotal,
       quoteQualify(customerCategory),
       quoteQualify(customerTags),
@@ -161,9 +164,11 @@ trait TestESData {
                             isCustomerDomain.toString, moderationEnabled.toString, routingApprovalEnabled.toString)
 
   private def buildEsDocByIndex(i: Int): String = {
+    val domainId = i % domainCnames.length
+    val domainApprovalIds = approvingDomainIds(i % approvingDomainIds.length)
     buildEsDoc(
       socrataIdDatasetIds(i % socrataIdDatasetIds.length),
-      i % domainCnames.length,
+      domainId,
       resourceDescriptions(i % resourceDescriptions.length),
       resourceNbeFxfs(i % resourceNbeFxfs.length),
       defaultResourceUpdatedAt,
@@ -184,7 +189,8 @@ trait TestESData {
       domainMetadata(i % domainMetadata.length),
       isDefaultViews(i % isDefaultViews.length),
       isModerationApproveds(i % isModerationApproveds.length),
-      approvingDomainIds(i % approvingDomainIds.length),
+      domainApprovalIds,
+      domainApprovalIds.contains(domainId),
       pageViewsTotal(i % pageViewsTotal.length),
       domainCategories(i % domainCategories.length),
       domainTags(i % domainTags.length),
@@ -309,7 +315,7 @@ trait TestESData {
         TypeDatasets.singular, viewtype = "", 0F,
         "", "", Seq.empty, Seq.empty, Seq.empty,
         Map.empty,
-        isDefaultView = false, Some(true), Seq(0),
+        isDefaultView = false, Some(true), Seq(0), isApprovedByParentDomain = true,
         "42", "Fun", Seq.empty, 0L
       )),
       (3, buildEsDoc(
@@ -319,7 +325,7 @@ trait TestESData {
         TypeDatasets.singular, viewtype = "", 0F,
         "", "", Seq.empty, Seq.empty, Seq.empty,
         Map.empty,
-        isDefaultView = false, Some(true), Seq(2,3),
+        isDefaultView = false, Some(true), Seq(2,3), isApprovedByParentDomain = true,
         "42", "Fun", Seq.empty, 0L
       ))
     ).foreach { case (domain, doc) =>

--- a/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -162,9 +162,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
                 }
               }
             },
-            {
-              "script": {"script" : "doc['approving_domain_ids'].values.contains(doc['socrata_id.domain_id'].value)"}
-            }
+            { "term": {"is_approved_by_parent_domain": true} }
           ]
         }
       }


### PR DESCRIPTION
**what it do**
* once etl/rammy precalculate this value, we can use a term query instead of the bulky script.
* again disable scripts

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata/cetera/130)
<!-- Reviewable:end -->
