### PR TITLE
Krah/domain norm refactor

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -79,7 +79,7 @@ object SearchServer extends App {
     val searchService = new SearchService(documentClient, domainClient, balboaClient)
 
     logger.info("Initializing FacetService with document client")
-    val facetService = new FacetService(documentClient)
+    val facetService = new FacetService(documentClient, domainClient)
 
     logger.info("Initializing DomainCountService with domain client")
     val domainCountService = new DomainCountService(domainClient)

--- a/cetera-http/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -56,15 +56,16 @@ object SearchServer extends App {
       ElasticSearchClient(config.elasticSearch))
     } {
 
+    val domainClient = new DomainClient(esClient, config.elasticSearch.indexAliasName)
     val documentClient = new DocumentClient(
       esClient,
+      domainClient,
       config.elasticSearch.indexAliasName,
       config.elasticSearch.titleBoost,
       config.elasticSearch.minShouldMatch,
       config.elasticSearch.functionScoreScripts.flatMap(fnName =>
       ScriptScoreFunction.getScriptFunction(fnName)).toSet
     )
-    val domainClient = new DomainClient(esClient, config.elasticSearch.indexAliasName)
 
     logger.info("ElasticSearchClient initialized on nodes " +
                   esClient.client.asInstanceOf[TransportClient].transportAddresses().toString)

--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/Router.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/Router.scala
@@ -16,7 +16,7 @@ class Router(
     catalogResource: => HttpService,
     facetResource: String => HttpService,
     domainCountResource: => HttpService,
-    countResource: CeteraFieldType with Countable with Rawable => HttpService) {
+    countResource: DocumentFieldType with Countable with Rawable => HttpService) {
 
   val routes = Routes(
     // /version is for internal use

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
@@ -24,7 +24,6 @@ object Aggregations {
               .filter("visible") // "visible" is an agg of documents matching the following filter
               .filter(
                 FilterBuilders.boolFilter()
-                  .must(Filters.customerDomainFilter.get)
                   .must(Filters.moderationStatusFilter().get)
                   .must(Filters.routingApprovalFilter(None, isDomainAgg = true).get)
               )

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
@@ -1,34 +1,15 @@
 package com.socrata.cetera.search
 
 import org.elasticsearch.index.query.FilterBuilders
-import org.elasticsearch.search.aggregations.{AbstractAggregationBuilder, AggregationBuilders}
 import org.elasticsearch.search.aggregations.bucket.terms.Terms
+import org.elasticsearch.search.aggregations.{AbstractAggregationBuilder, AggregationBuilders}
 
 import com.socrata.cetera._
 import com.socrata.cetera.types._
 
-object Aggregations {
+object DocumentAggregations {
   // The 'terms' and 'nested' fields need to jive with
   // ../services/CountService.scala
-
-  val domains =
-    AggregationBuilders
-      .terms("domains") // "domains" is an agg of terms on field "domain_cname.raw"
-      .field("domain_cname.raw")
-      .subAggregation(
-        AggregationBuilders
-          .children("documents") // "documents" is an agg of children of type esDocumentType
-          .childType(esDocumentType)
-          .subAggregation(
-            AggregationBuilders
-              .filter("visible") // "visible" is an agg of documents matching the following filter
-              .filter(
-                FilterBuilders.boolFilter()
-                  .must(DocumentFilters.moderationStatusFilter().get)
-                  .must(DocumentFilters.routingApprovalFilter(None, isDomainAgg = true).get)
-              )
-          )
-      )
 
   val domainCategories =
     AggregationBuilders
@@ -66,13 +47,38 @@ object Aggregations {
           .size(0)
       )
 
-  def chooseAggregation(field: CeteraFieldType with Countable with Rawable) : AbstractAggregationBuilder =
+  def chooseAggregation(field: CeteraFieldType with Countable with Rawable): AbstractAggregationBuilder =
     field match {
-      case DomainCnameFieldType => Aggregations.domains
-      case DomainCategoryFieldType => Aggregations.domainCategories
-      case DomainTagsFieldType => Aggregations.domainTags
-
-      case CategoriesFieldType => Aggregations.categories
-      case TagsFieldType => Aggregations.tags
+      case DomainCategoryFieldType => domainCategories
+      case DomainTagsFieldType => domainTags
+      case CategoriesFieldType => categories
+      case TagsFieldType => tags
+      case _ => ???
     }
+}
+
+object DomainAggregations {
+  def domains(searchContextIsMod: Boolean,
+              modDomainIds: Seq[Int] = Seq.empty,
+              unmodDomainIds: Seq[Int] = Seq.empty): AbstractAggregationBuilder = {
+    AggregationBuilders
+      .terms("domains") // "domains" is an agg of terms on field "domain_cname.raw"
+      .field("domain_cname.raw")
+      .subAggregation(
+        AggregationBuilders
+          .children("documents") // "documents" is an agg of children of type esDocumentType
+          .childType(esDocumentType)
+          .subAggregation(
+            AggregationBuilders
+              .filter("visible") // "visible" is an agg of documents matching the following filter
+              .filter(FilterBuilders.boolFilter()
+                // is customer domain filter must be applied above this aggregation
+                // apply moderation filter
+                .must(DocumentFilters.moderationStatusFilter(searchContextIsMod, modDomainIds, unmodDomainIds).get)
+                // apply routing & approval filter
+                .must(DocumentFilters.routingApprovalFilter(None, isDomainAgg = true).get)
+              )
+          )
+      )
+  }
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
@@ -58,14 +58,22 @@ object DocumentAggregations {
 }
 
 object DomainAggregations {
-  def domains(searchContextIsMod: Boolean,
-              modDomainIds: Set[Int],
-              unmodDomainIds: Set[Int],
-              raOffDomainIds: Set[Int]): AbstractAggregationBuilder = {
-    val moderationFilter =
-      DocumentFilters.moderationStatusFilter(searchContextIsMod, modDomainIds, unmodDomainIds, isDomainAgg = true)
-    val routingApprovalFilter =
-      DocumentFilters.routingApprovalFilter(None, raOffDomainIds, isDomainAgg = true)
+  def domains(searchContextIsModerated: Boolean,
+              moderatedDomainIds: Set[Int],
+              unmoderatedDomainIds: Set[Int],
+              routingApprovalDisabledDomainIds: Set[Int]
+             ): AbstractAggregationBuilder = {
+    val moderationFilter = DocumentFilters.moderationStatusFilter(
+      searchContextIsModerated,
+      moderatedDomainIds,
+      unmoderatedDomainIds,
+      isDomainAgg = true
+    )
+    val routingApprovalFilter = DocumentFilters.routingApprovalFilter(
+      None,
+      routingApprovalDisabledDomainIds,
+      isDomainAgg = true
+    )
     AggregationBuilders
       .terms("domains") // "domains" is an agg of terms on field "domain_cname.raw"
       .field("domain_cname.raw")

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
@@ -60,11 +60,12 @@ object DocumentAggregations {
 object DomainAggregations {
   def domains(searchContextIsMod: Boolean,
               modDomainIds: Set[Int],
-              unmodDomainIds: Set[Int]): AbstractAggregationBuilder = {
+              unmodDomainIds: Set[Int],
+              raOffDomainIds: Set[Int]): AbstractAggregationBuilder = {
     val moderationFilter =
       DocumentFilters.moderationStatusFilter(searchContextIsMod, modDomainIds, unmodDomainIds, isDomainAgg = true)
     val routingApprovalFilter =
-      DocumentFilters.routingApprovalFilter(None, isDomainAgg = true).get
+      DocumentFilters.routingApprovalFilter(None, raOffDomainIds, isDomainAgg = true)
     AggregationBuilders
       .terms("domains") // "domains" is an agg of terms on field "domain_cname.raw"
       .field("domain_cname.raw")

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
@@ -24,8 +24,8 @@ object Aggregations {
               .filter("visible") // "visible" is an agg of documents matching the following filter
               .filter(
                 FilterBuilders.boolFilter()
-                  .must(Filters.moderationStatusFilter().get)
-                  .must(Filters.routingApprovalFilter(None, isDomainAgg = true).get)
+                  .must(DocumentFilters.moderationStatusFilter().get)
+                  .must(DocumentFilters.routingApprovalFilter(None, isDomainAgg = true).get)
               )
           )
       )

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
@@ -47,13 +47,13 @@ object DocumentAggregations {
           .size(0)
       )
 
-  def chooseAggregation(field: CeteraFieldType with Countable with Rawable): AbstractAggregationBuilder =
+  def chooseAggregation(field: DocumentFieldType with Countable with Rawable): AbstractAggregationBuilder =
     field match {
       case DomainCategoryFieldType => domainCategories
       case DomainTagsFieldType => domainTags
+
       case CategoriesFieldType => categories
       case TagsFieldType => tags
-      case _ => ???
     }
 }
 

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Boosts.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Boosts.scala
@@ -3,8 +3,7 @@ package com.socrata.cetera.search
 import org.elasticsearch.index.query.functionscore.{FunctionScoreQueryBuilder, ScoreFunctionBuilders}
 import org.elasticsearch.index.query.{BoolQueryBuilder, FilterBuilders, QueryBuilders}
 
-import com.socrata.cetera._
-import com.socrata.cetera.types._
+import com.socrata.cetera.types.{Datatype, DatatypeFieldType, ScriptScoreFunction, SocrataIdDomainIdFieldType}
 
 object Boosts {
   def applyDatatypeBoosts(

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Boosts.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Boosts.scala
@@ -1,7 +1,7 @@
 package com.socrata.cetera.search
 
-import org.elasticsearch.index.query.{BoolQueryBuilder, FilterBuilders, QueryBuilders}
 import org.elasticsearch.index.query.functionscore.{FunctionScoreQueryBuilder, ScoreFunctionBuilders}
+import org.elasticsearch.index.query.{BoolQueryBuilder, FilterBuilders, QueryBuilders}
 
 import com.socrata.cetera._
 import com.socrata.cetera.types.{Datatype, DatatypeFieldType, DomainCnameFieldType, ScriptScoreFunction}
@@ -41,6 +41,7 @@ object Boosts {
     domainBoosts.foreach {
       case (domain, weight) =>
         query.add(
+          // TODO: refactor out has_parent filters
           FilterBuilders.hasParentFilter(esDomainType,
             FilterBuilders.termFilter(DomainCnameFieldType.rawFieldName, domain)
           ),

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Boosts.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Boosts.scala
@@ -4,7 +4,7 @@ import org.elasticsearch.index.query.functionscore.{FunctionScoreQueryBuilder, S
 import org.elasticsearch.index.query.{BoolQueryBuilder, FilterBuilders, QueryBuilders}
 
 import com.socrata.cetera._
-import com.socrata.cetera.types.{Datatype, DatatypeFieldType, DomainCnameFieldType, ScriptScoreFunction}
+import com.socrata.cetera.types._
 
 object Boosts {
   def applyDatatypeBoosts(
@@ -35,16 +35,13 @@ object Boosts {
 
   def applyDomainBoosts(
       query: FunctionScoreQueryBuilder,
-      domainBoosts: Map[String, Float])
+      domainIdBoosts: Map[Int, Float])
     : Unit = {
 
-    domainBoosts.foreach {
-      case (domain, weight) =>
+    domainIdBoosts.foreach {
+      case (domainId, weight) =>
         query.add(
-          // TODO: refactor out has_parent filters
-          FilterBuilders.hasParentFilter(esDomainType,
-            FilterBuilders.termFilter(DomainCnameFieldType.rawFieldName, domain)
-          ),
+          FilterBuilders.termFilter(SocrataIdDomainIdFieldType.fieldName, domainId),
           ScoreFunctionBuilders.weightFactorFunction(weight)
         )
     }

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -277,7 +277,7 @@ class DocumentClient(
   }
 
   def buildCountRequest(
-      field: CeteraFieldType with Countable with Rawable,
+      field: DocumentFieldType with Countable with Rawable,
       searchQuery: QueryType,
       domainIds: Set[Int],
       searchContext: Option[Domain],

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -94,7 +94,6 @@ class DocumentClient(
 
     QueryBuilders.boolQuery()
       .should(documentQuery)
-      // TODO: refactor out has_parent queries
       .should(QueryBuilders.hasParentQuery(esDomainType, domainQuery))
   }
 

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -196,7 +196,7 @@ class DocumentClient(
       only: Option[Seq[String]],
       fieldBoosts: Map[CeteraFieldType with Boostable, Float],
       datatypeBoosts: Map[Datatype, Float],
-      domainBoosts: Map[String, Float],
+      domainIdBoosts: Map[Int, Float],
       minShouldMatch: Option[String],
       slop: Option[Int])
     : SearchRequestBuilder = {
@@ -224,7 +224,7 @@ class DocumentClient(
     // Wrap filtered query in function score query for boosting
     val query = QueryBuilders.functionScoreQuery(filteredQuery)
     Boosts.applyScoreFunctions(query, scriptScoreFunctions)
-    Boosts.applyDomainBoosts(query, domainBoosts)
+    Boosts.applyDomainBoosts(query, domainIdBoosts)
     query.scoreMode("multiply").boostMode("replace")
 
     val preparedSearch = esClient.client
@@ -245,7 +245,7 @@ class DocumentClient(
       only: Option[Seq[String]],
       fieldBoosts: Map[CeteraFieldType with Boostable, Float],
       datatypeBoosts: Map[Datatype, Float],
-      domainBoosts: Map[String, Float],
+      domainIdBoosts: Map[Int, Float],
       minShouldMatch: Option[String],
       slop: Option[Int],
       offset: Int,
@@ -263,7 +263,7 @@ class DocumentClient(
       only,
       fieldBoosts,
       datatypeBoosts,
-      domainBoosts,
+      domainIdBoosts,
       minShouldMatch,
       slop
     )

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -6,7 +6,6 @@ import org.elasticsearch.search.aggregations.AggregationBuilders
 
 import com.socrata.cetera._
 import com.socrata.cetera.search.DocumentAggregations._
-import com.socrata.cetera.search.DocumentFilters._
 import com.socrata.cetera.types._
 
 class DocumentClient(
@@ -97,6 +96,31 @@ class DocumentClient(
       .should(QueryBuilders.hasParentQuery(esDomainType, domainQuery))
   }
 
+  private def buildFilter(datatypes: Option[Seq[String]],
+                          queryDomainIds: Set[Int],
+                          searchContext: Option[Domain],
+                          categories: Option[Set[String]],
+                          tags: Option[Set[String]],
+                          domainMetadata: Option[Set[(String, String)]]): FilterBuilder = {
+
+    import com.socrata.cetera.search.DocumentFilters._ // scalastyle:ignore import.grouping
+
+
+    val contextModerated = searchContext.exists(_.moderationEnabled)
+    val (domainIds, moderatedDomainIds, unmoderatedDomainIds, routingApprovalDisabledDomainIds) =
+      domainClient.calculateIdsAndModRAStatuses(domainClient.fetchOrAllCustomerDomains(queryDomainIds))
+
+    val filter = FilterBuilders.boolFilter()
+    List.concat(
+      datatypeFilter(datatypes),
+      domainIdsFilter(domainIds),
+      Some(moderationStatusFilter(contextModerated, moderatedDomainIds, unmoderatedDomainIds)),
+      Some(routingApprovalFilter(searchContext, routingApprovalDisabledDomainIds)),
+      searchContext.flatMap(_ => domainMetadataFilter(domainMetadata))
+    ).foreach(filter.must)
+    filter
+  }
+
   private def buildFilteredQuery(
       datatypes: Option[Seq[String]],
       queryDomainIds: Set[Int],
@@ -106,6 +130,8 @@ class DocumentClient(
       domainMetadata: Option[Set[(String, String)]],
       query: BaseQueryBuilder)
     : BaseQueryBuilder = {
+
+    import com.socrata.cetera.search.DocumentQueries._ // scalastyle:ignore import.grouping
 
     // If there is no search context, use the ODN categories and tags and prohibit domain metadata
     // otherwise use the custom domain categories, tags, metadata
@@ -120,29 +146,17 @@ class DocumentClient(
           tagsQuery(tags))
       }
 
-    val contextModerated = searchContext.exists(_.moderationEnabled)
-    val (domainIds, moderatedDomainIds, unmoderatedDomainIds, routingApprovalDisabledDomainIds) =
-      domainClient.calculateIdsAndModRAStatuses(domainClient.fetchOrAllCustomerDomains(queryDomainIds))
-
-    val filters: List[FilterBuilder] = List.concat(
-      datatypeFilter(datatypes),
-      domainIdsFilter(domainIds),
-      Some(moderationStatusFilter(contextModerated, moderatedDomainIds, unmoderatedDomainIds)),
-      Some(routingApprovalFilter(searchContext, routingApprovalDisabledDomainIds)),
-      searchContext.flatMap(_ => domainMetadataFilter(domainMetadata))
-    )
-
     val categoriesAndTagsQuery =
       if (categoriesAndTags.nonEmpty) {
         categoriesAndTags.foldLeft(QueryBuilders.boolQuery().must(query)) { (b, q) => b.must(q) }
       } else { query }
 
-    if (filters.nonEmpty) {
-      QueryBuilders.filteredQuery(
-        categoriesAndTagsQuery,
-        FilterBuilders.andFilter(filters.toSeq: _*)
-      )
-    } else { categoriesAndTagsQuery }
+    val filter = buildFilter(datatypes, queryDomainIds, searchContext, categories, tags, domainMetadata)
+
+    QueryBuilders.filteredQuery(
+      categoriesAndTagsQuery,
+      filter
+    )
   }
 
   private def applyDefaultTitleBoost(
@@ -336,7 +350,7 @@ class DocumentClient(
           .field(DomainMetadataFieldType.Value.rawFieldName)
           .size(size)))
 
-    val filter = domainId.flatMap(i => domainIdFilter(i))
+    val filter = domainId.map(i => buildFilter(None, Set(i), None, None, None, None))
       .getOrElse(FilterBuilders.matchAllFilter())
 
     val filteredAggs = AggregationBuilders

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -5,6 +5,7 @@ import org.elasticsearch.index.query._
 import org.elasticsearch.search.aggregations.AggregationBuilders
 
 import com.socrata.cetera._
+import com.socrata.cetera.search.DocumentAggregations._
 import com.socrata.cetera.search.DocumentFilters._
 import com.socrata.cetera.types._
 
@@ -292,7 +293,7 @@ class DocumentClient(
       only: Option[Seq[String]])
     : SearchRequestBuilder = {
 
-    val aggregation = Aggregations.chooseAggregation(field)
+    val aggregation = chooseAggregation(field)
 
     val baseRequest = buildBaseRequest(
       searchQuery,

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -107,8 +107,14 @@ class DocumentClient(
 
 
     val contextModerated = searchContext.exists(_.moderationEnabled)
-    val (domainIds, moderatedDomainIds, unmoderatedDomainIds, routingApprovalDisabledDomainIds) =
-      domainClient.calculateIdsAndModRAStatuses(domainClient.fetchOrAllCustomerDomains(queryDomainIds))
+    val (
+      domainIds,
+      moderatedDomainIds,
+      unmoderatedDomainIds,
+      routingApprovalDisabledDomainIds
+      ) = domainClient.calculateIdsAndModRAStatuses(
+        domainClient.fetchOrAllCustomerDomains(queryDomainIds)
+    )
 
     val filter = FilterBuilders.boolFilter()
     List.concat(

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -5,6 +5,7 @@ import org.elasticsearch.index.query._
 import org.elasticsearch.search.aggregations.AggregationBuilders
 
 import com.socrata.cetera._
+import com.socrata.cetera.search.DocumentFilters._
 import com.socrata.cetera.types._
 
 class DocumentClient(
@@ -92,6 +93,7 @@ class DocumentClient(
 
     QueryBuilders.boolQuery()
       .should(documentQuery)
+      // TODO: refactor out has_parent queries
       .should(QueryBuilders.hasParentQuery(esDomainType, domainQuery))
   }
 
@@ -104,8 +106,6 @@ class DocumentClient(
       domainMetadata: Option[Set[(String, String)]],
       query: BaseQueryBuilder)
     : BaseQueryBuilder = {
-
-    import com.socrata.cetera.search.Filters._ // scalastyle:ignore import.grouping
 
     // If there is no search context, use the ODN categories and tags and prohibit domain metadata
     // otherwise use the custom domain categories, tags, metadata
@@ -342,7 +342,7 @@ class DocumentClient(
           .field(DomainMetadataFieldType.Value.rawFieldName)
           .size(size)))
 
-    val filter = domainId.flatMap(i => Filters.domainIdFilter(i))
+    val filter = domainId.flatMap(i => domainIdFilter(i))
       .getOrElse(FilterBuilders.matchAllFilter())
 
     val filteredAggs = AggregationBuilders

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -16,6 +16,7 @@ class DomainClient(val esClient: ElasticSearchClient, val indexAliasName: String
   val logger = LoggerFactory.getLogger(getClass)
 
   def fetch(id: Int): Option[Domain] = {
+    logger.debug(s"fetching domain id $id")
     val res = esClient.client.prepareGet(indexAliasName, esDomainType, id.toString)
       .execute.actionGet
     Domain(res.getSourceAsString)

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -43,7 +43,10 @@ class DomainClient(val esClient: ElasticSearchClient, val indexAliasName: String
 
   def odnSearch: Seq[Domain] = {
     val search = esClient.client.prepareSearch(indexAliasName).setTypes(esDomainType)
-      .setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), isCustomerDomainFilter))
+      .setQuery(QueryBuilders.filteredQuery(
+        QueryBuilders.matchAllQuery(),
+        isCustomerDomainFilter)
+      )
     logger.debug(LogHelper.formatEsRequest(search))
     val res = search.execute.actionGet
     res.getHits.hits.flatMap { h =>

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -1,7 +1,6 @@
 package com.socrata.cetera.search
 
-import com.rojoma.json.v3.codec.JsonDecode
-import com.rojoma.json.v3.io.JsonReader
+import com.rojoma.json.v3.util.JsonUtil
 import org.elasticsearch.action.search.{SearchRequestBuilder, SearchType}
 import org.elasticsearch.index.query.QueryBuilders
 import org.slf4j.LoggerFactory
@@ -10,7 +9,7 @@ import com.socrata.cetera._
 import com.socrata.cetera.search.DomainAggregations._
 import com.socrata.cetera.search.DomainFilters._
 import com.socrata.cetera.types.{Domain, DomainCnameFieldType, QueryType}
-import com.socrata.cetera.util.LogHelper
+import com.socrata.cetera.util.{JsonDecodeException, LogHelper}
 
 class DomainClient(val esClient: ElasticSearchClient, val indexAliasName: String) {
   val logger = LoggerFactory.getLogger(getClass)
@@ -22,27 +21,36 @@ class DomainClient(val esClient: ElasticSearchClient, val indexAliasName: String
     Domain(res.getSourceAsString)
   }
 
-  def find(cname: String): Option[Domain] = {
+  def find(cname: String): Option[Domain] = find(Set(cname)).headOption
+
+  def find(cnames: Set[String]): Set[Domain] = {
+    val query = QueryBuilders.boolQuery()
+    cnames.foreach(s => query.should(QueryBuilders.matchPhraseQuery(DomainCnameFieldType.fieldName, s)))
     val search = esClient.client.prepareSearch(indexAliasName).setTypes(esDomainType)
-      .setQuery(QueryBuilders.matchPhraseQuery(DomainCnameFieldType.fieldName, cname))
+      .setQuery(query)
     logger.debug(LogHelper.formatEsRequest(search))
+
     val res = search.execute.actionGet
-    val hits = res.getHits.hits
-    hits.length match {
-      case 0 => None
-      case n: Int =>
-        val domainAsJvalue = JsonReader.fromString(hits(0).getSourceAsString)
-        val domainDecode = JsonDecode.fromJValue[Domain](domainAsJvalue)
-        domainDecode match {
-          case Right(domain) => Some(domain)
-          case Left(err) =>
-            logger.error(err.english)
-            throw new Exception(s"Error decoding $esDomainType $cname")
-        }
+    res.getHits.hits.flatMap { h =>
+      JsonUtil.parseJson[Domain](h.sourceAsString) match {
+        case Right(domain) => Some(domain)
+        case Left(err) =>
+          logger.error(err.english)
+          throw new JsonDecodeException(err)
+      }
+    }.toSet
+  }
+
+  // if domain cname filter is provided limit to that scope, otherwise default to publicly visible domains
+  def findRelevantDomains(searchContextCname: Option[String], domainCnames: Set[String]): Set[Domain] = {
+    searchContextCname.foldLeft(domainCnames) { (b, x) => b + x } match {
+      case cs: Set[String] if cs.nonEmpty => find(cs)
+      case _ => customerDomainSearch.toSet
     }
   }
 
-  def odnSearch: Seq[Domain] = {
+  // when query doesn't define domain filter, we assume all customer domains.
+  private def customerDomainSearch: Seq[Domain] = {
     val search = esClient.client.prepareSearch(indexAliasName).setTypes(esDomainType)
       .setQuery(QueryBuilders.filteredQuery(
         QueryBuilders.matchAllQuery(),
@@ -55,18 +63,6 @@ class DomainClient(val esClient: ElasticSearchClient, val indexAliasName: String
     }
   }
 
-  def fetchOrAllCustomerDomains(domainIds: Set[Int]): Set[Domain] =
-    domainIds.flatMap(fetch) match {
-      case ds: Set[Domain] if ds.nonEmpty => ds
-      case _ => odnSearch.toSet
-    }
-
-  def findOrAllCustomerDomains(domainCnames: Set[String]): Set[Domain] =
-    domainCnames.flatMap(find) match {
-      case ds: Set[Domain] if ds.nonEmpty => ds
-      case _ => odnSearch.toSet
-    }
-
   // (pre-)calculate domain moderation and R+A status
   def calculateIdsAndModRAStatuses(domains: Set[Domain]): (Set[Int], Set[Int], Set[Int], Set[Int]) = {
     val ids = domains.map(_.domainId)
@@ -78,7 +74,7 @@ class DomainClient(val esClient: ElasticSearchClient, val indexAliasName: String
 
   def buildCountRequest(
       searchQuery: QueryType,
-      domainCnames: Set[String],
+      searchDomains: Set[Domain],
       searchContext: Option[Domain],
       categories: Option[Set[String]],
       tags: Option[Set[String]],
@@ -86,7 +82,7 @@ class DomainClient(val esClient: ElasticSearchClient, val indexAliasName: String
     : SearchRequestBuilder = {
     val (domainsFilter, domainsAggregation) = {
       val contextMod = searchContext.exists(_.moderationEnabled)
-      val (ids, mod, unmod, raOff) = calculateIdsAndModRAStatuses(findOrAllCustomerDomains(domainCnames))
+      val (ids, mod, unmod, raOff) = calculateIdsAndModRAStatuses(searchDomains)
       val dsFilter = if (ids.nonEmpty) domainIds(ids) else isCustomerDomainFilter
       val dsAggregation = domains(contextMod, mod, unmod, raOff)
       (dsFilter, dsAggregation)

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -53,3 +53,5 @@ class DomainClient(val esClient: ElasticSearchClient, val indexAliasName: String
       .setSearchType("count")
   }
 }
+
+class DomainNotFound(cname: String) extends NoSuchElementException(cname)

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -46,6 +46,7 @@ object DocumentQueries {
 object DocumentFilters {
   def datatypeFilter(datatypes: Option[Seq[String]], aggPrefix: String = ""): Option[FilterBuilder] =
     datatypes.map(ts => datatypeFilter(ts, aggPrefix))
+
   def datatypeFilter(datatypes: Seq[String], aggPrefix: String): FilterBuilder = {
     val validatedDatatypes = datatypes.flatMap(t => Datatype(t).map(_.singular))
     termsFilter(aggPrefix + DatatypeFieldType.fieldName, validatedDatatypes: _*)

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -68,10 +68,12 @@ object Filters {
       )
     }
 
-  def customerDomainFilter: Option[FilterBuilder] =
-    Some(hasParentFilter(esDomainType,
-      notFilter(termFilter(IsCustomerDomainFieldType.fieldName, false))
-    ))
+  def isCustomerDomainFilter: FilterBuilder =
+    notFilter(termFilter(IsCustomerDomainFieldType.fieldName, false))
+
+  def documentInDomainIdsFilter(domainIds: Seq[Int]): Option[FilterBuilder] = {
+    Some(termsFilter(SocrataIdDomainIdFieldType.fieldName, domainIds: _*))
+  }
 
   /**
     * Filter to only show documents that have passed the view moderation workflow.

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -14,17 +14,10 @@ object Filters {
       termsFilter(DatatypeFieldType.fieldName, validatedDatatypes: _*)
     }
 
-  def domainFilter(domains: Set[String]): Option[FilterBuilder] =
-    if (domains.nonEmpty) {
-      Some(hasParentFilter(esDomainType,
-        termsFilter(DomainCnameFieldType.rawFieldName, domains.toSeq: _*)
-      ))
-    } else {
-      None
-    }
+  def domainIdFilter(domainIds: Set[Int]): Option[FilterBuilder] =
+    if (domainIds.nonEmpty) Some(termsFilter(SocrataIdDomainIdFieldType.fieldName, domainIds.toSeq: _*)) else None
 
-  def domainFilter(domain: String): Option[FilterBuilder] =
-    if (domain.nonEmpty) domainFilter(Set(domain)) else None
+  def domainIdFilter(domainId: Int): Option[FilterBuilder] = domainIdFilter(Set(domainId))
 
   def categoriesQuery(categories: Option[Set[String]]): Option[QueryBuilder] =
     categories.map { cs =>

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -85,7 +85,9 @@ object DocumentFilters {
     * @param searchContextIsModerated is the catalog search context view moderated?
     * @return composable filter builder
     */
-  def moderationStatusFilter(searchContextIsModerated: Boolean = false): Option[FilterBuilder] = {
+  def moderationStatusFilter(searchContextIsModerated: Boolean = false,
+                             moderatedDomainIds: Seq[Int] = Seq.empty,
+                             unmoderatedDomainIds: Seq[Int] = Seq.empty): Option[FilterBuilder] = {
     val documentIsDefault = termFilter(IsDefaultViewFieldType.fieldName, true)
     val documentIsAccepted = termFilter(IsModerationApprovedFieldType.fieldName, true)
 

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -7,25 +7,7 @@ import org.elasticsearch.index.query.{FilterBuilder, QueryBuilder}
 import com.socrata.cetera._
 import com.socrata.cetera.types._
 
-object DocumentFilters {
-  def datatypeFilter(datatypes: Option[Seq[String]], aggPrefix: String = ""): Option[FilterBuilder] =
-    datatypes.map(ts => datatypeFilter(ts, aggPrefix))
-  def datatypeFilter(datatypes: Seq[String], aggPrefix: String): FilterBuilder = {
-    val validatedDatatypes = datatypes.flatMap(t => Datatype(t).map(_.singular))
-    termsFilter(aggPrefix + DatatypeFieldType.fieldName, validatedDatatypes: _*)
-  }
-
-  def domainIdsFilter(domainIds: Set[Int], aggPrefix: String = ""): Option[FilterBuilder] =
-    if (domainIds.nonEmpty) {
-      Some(termsFilter(aggPrefix + SocrataIdDomainIdFieldType.fieldName, domainIds.toSeq: _*))
-    } else { None }
-
-  def domainIdFilter(domainId: Int, aggPrefix: String = ""): Option[FilterBuilder] =
-    domainIdsFilter(Set(domainId), aggPrefix)
-
-  def isApprovedByParentDomainFilter(aggPrefix: String = ""): Option[FilterBuilder] =
-    Some(termFilter(aggPrefix + "is_approved_by_parent_domain", true))
-
+object DocumentQueries {
   def categoriesQuery(categories: Option[Set[String]]): Option[QueryBuilder] =
     categories.map { cs =>
       nestedQuery(
@@ -59,6 +41,26 @@ object DocumentFilters {
         b.should(matchQuery(DomainTagsFieldType.fieldName, q))
       }
     }
+}
+
+object DocumentFilters {
+  def datatypeFilter(datatypes: Option[Seq[String]], aggPrefix: String = ""): Option[FilterBuilder] =
+    datatypes.map(ts => datatypeFilter(ts, aggPrefix))
+  def datatypeFilter(datatypes: Seq[String], aggPrefix: String): FilterBuilder = {
+    val validatedDatatypes = datatypes.flatMap(t => Datatype(t).map(_.singular))
+    termsFilter(aggPrefix + DatatypeFieldType.fieldName, validatedDatatypes: _*)
+  }
+
+  def domainIdsFilter(domainIds: Set[Int], aggPrefix: String = ""): Option[FilterBuilder] =
+    if (domainIds.nonEmpty) {
+      Some(termsFilter(aggPrefix + SocrataIdDomainIdFieldType.fieldName, domainIds.toSeq: _*))
+    } else { None }
+
+  def domainIdFilter(domainId: Int, aggPrefix: String = ""): Option[FilterBuilder] =
+    domainIdsFilter(Set(domainId), aggPrefix)
+
+  def isApprovedByParentDomainFilter(aggPrefix: String = ""): Option[FilterBuilder] =
+    Some(termFilter(aggPrefix + "is_approved_by_parent_domain", true))
 
   def domainMetadataFilter(metadata: Option[Set[(String, String)]]): Option[FilterBuilder] =
     metadata.map { ss =>

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/SundryBuilders.scala
@@ -2,6 +2,8 @@ package com.socrata.cetera.search
 
 import org.elasticsearch.index.query.{MultiMatchQueryBuilder, QueryBuilders}
 
+import com.socrata.cetera.types.{FullTextSearchAnalyzedFieldType, FullTextSearchRawFieldType}
+
 object SundryBuilders {
   def applyMinMatchConstraint(query: MultiMatchQueryBuilder, constraint: String): Unit =
     query.minimumShouldMatch(constraint)
@@ -11,7 +13,7 @@ object SundryBuilders {
 
   def multiMatch(q: String, mmType: MultiMatchQueryBuilder.Type): MultiMatchQueryBuilder =
     QueryBuilders.multiMatchQuery(q)
-      .field("fts_analyzed")
-      .field("fts_raw")
+      .field(FullTextSearchAnalyzedFieldType.fieldName)
+      .field(FullTextSearchRawFieldType.fieldName)
       .`type`(mmType)
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -41,7 +41,7 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
   def format(counts: Seq[JValue]): SearchResults[Count] =
     SearchResults(counts.map { c => Count(c.dyn.key.!, c.dyn.doc_count.!) })
 
-  def doAggregate(field: CeteraFieldType with Countable with Rawable,
+  def doAggregate(field: DocumentFieldType with Countable with Rawable,
                   queryParameters: MultiQueryParams): (SearchResults[Count], InternalTimings) = {
     val now = Timings.now()
 
@@ -78,9 +78,8 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
   }
 
   // $COVERAGE-OFF$ jetty wiring
-  def aggregate(field: CeteraFieldType with Countable with Rawable)(req: HttpRequest): HttpResponse = {
+  def aggregate(field: DocumentFieldType with Countable with Rawable)(req: HttpRequest): HttpResponse = {
     implicit val cEncode = field match {
-      case DomainCnameFieldType => Count.encode(esDomainType)
       case CategoriesFieldType => Count.encode("category")
       case TagsFieldType => Count.encode("tag")
       case DomainCategoryFieldType => Count.encode("domain_category")
@@ -102,7 +101,7 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
     }
   }
 
-  case class Service(field: CeteraFieldType with Countable with Rawable) extends SimpleResource {
+  case class Service(field: DocumentFieldType with Countable with Rawable) extends SimpleResource {
     override def get: HttpService = aggregate(field)
   }
   // $COVERAGE-ON$

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -51,12 +51,13 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
         throw new IllegalArgumentException(s"Invalid query parameters: $msg")
 
       case Right(params) =>
-        val domain = params.searchContext.flatMap(domainClient.find)
+        val searchContext = params.searchContext.flatMap(domainClient.find)
+        val domainIds = params.domains.flatMap(cname => domainClient.find(cname).map(_.domainId))
         val search = documentClient.buildCountRequest(
           field,
           params.searchQuery,
-          params.domains,
-          domain,
+          domainIds,
+          searchContext,
           params.categories,
           params.tags,
           params.only

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -51,7 +51,7 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
         throw new IllegalArgumentException(s"Invalid query parameters: $msg")
 
       case Right(params) =>
-        val relevantDomains = domainClient.findRelevantDomains(params.searchContext, params.domains)
+        val (relevantDomains, domainSearchTime) = domainClient.findRelevantDomains(params.searchContext, params.domains)
         val searchContext = params.searchContext.flatMap(cname => relevantDomains.find(_.domainCname == cname))
         val queryDomains = params.domains match {
           case cs: Set[String] if cs.nonEmpty => cs.flatMap(cname => relevantDomains.find(_.domainCname == cname))
@@ -69,7 +69,7 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
         )
         logger.info(LogHelper.formatEsRequest(search))
         val res = search.execute.actionGet
-        val timings = InternalTimings(Timings.elapsedInMillis(now), Option(res.getTookInMillis))
+        val timings = InternalTimings(Timings.elapsedInMillis(now), Seq(domainSearchTime, res.getTookInMillis))
         val json = JsonReader.fromString(res.toString)
         val counts = extract(json) match {
           case Right(extracted) => extracted

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/DomainCountService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/DomainCountService.scala
@@ -46,11 +46,13 @@ class DomainCountService(domainClient: DomainClient) {
         throw new IllegalArgumentException(s"Invalid query parameters: $msg")
 
       case Right(params) =>
-        val domain = params.searchContext.flatMap(domainClient.find)
+        val relevantDomains = domainClient.findRelevantDomains(params.searchContext, params.domains)
+        val searchContext = params.searchContext.flatMap(cname => relevantDomains.find(_.domainCname == cname))
+
         val search = domainClient.buildCountRequest(
           params.searchQuery,
-          params.domains,
-          domain,
+          relevantDomains,
+          searchContext,
           params.categories,
           params.tags,
           params.only

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/FacetService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/FacetService.scala
@@ -49,8 +49,8 @@ class FacetService(documentClient: DocumentClient, domainClient: DomainClient) {
   def doAggregate(cname: String): (Seq[FacetCount], InternalTimings) = {
     val startMs = Timings.now()
 
-    val domainId = Some(domainClient.find(cname).getOrElse(throw new DomainNotFound(cname)).domainId)
-    val request = documentClient.buildFacetRequest(domainId)
+    val domain = Some(domainClient.find(cname).getOrElse(throw new DomainNotFound(cname)))
+    val request = documentClient.buildFacetRequest(domain)
     logger.info(LogHelper.formatEsRequest(request))
     val res = request.execute().actionGet()
     val aggs = res.getAggregations.asMap().asScala

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -173,10 +173,11 @@ class SearchService(elasticSearchClient: DocumentClient,
 
       case Right(params) =>
         val searchContext = params.searchContext.flatMap(domainClient.find)
+        val domainIds = params.domains.flatMap(cname => domainClient.find(cname).map(_.domainId))
 
         val req = elasticSearchClient.buildSearchRequest(
           params.searchQuery,
-          params.domains,
+          domainIds,
           params.domainMetadata,
           searchContext,
           params.categories,

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -10,6 +10,9 @@ sealed trait CeteraFieldType {
   val fieldName: String
 }
 
+sealed trait DocumentFieldType extends CeteraFieldType
+sealed trait DomainFieldType extends CeteraFieldType
+
 // A field that can be boosted (i.e, fields like title or description that can
 // have extra weight given to then when matching keyword queries).
 sealed trait Boostable extends CeteraFieldType
@@ -62,7 +65,7 @@ case object FullTextSearchAnalyzedFieldType extends CeteraFieldType {
 case object FullTextSearchRawFieldType extends CeteraFieldType {
   val fieldName: String = "fts_raw"
 }
-case object DomainCnameFieldType extends CeteraFieldType with Countable with Rawable {
+case object DomainCnameFieldType extends DomainFieldType with Countable with Rawable {
   val fieldName: String = "domain_cname"
 }
 
@@ -70,7 +73,7 @@ case object DomainCnameFieldType extends CeteraFieldType with Countable with Raw
 // Categories & Tags
 
 // Categories have a score and a raw field name available
-case object CategoriesFieldType extends Scorable with Rawable {
+case object CategoriesFieldType extends DocumentFieldType with Scorable with Rawable {
   val fieldName: String = "animl_annotations.categories"
 
   case object Name extends NestedField with Rawable {
@@ -83,7 +86,7 @@ case object CategoriesFieldType extends Scorable with Rawable {
 }
 
 // Tags have a score and a raw field name available
-case object TagsFieldType extends Scorable with Rawable {
+case object TagsFieldType extends DocumentFieldType with Scorable with Rawable {
   val fieldName: String = "animl_annotations.tags"
 
   case object Name extends NestedField with Rawable {
@@ -98,7 +101,7 @@ case object TagsFieldType extends Scorable with Rawable {
 // TODO: cetera-etl rename customer_category to domain_category
 // A domain category is a domain-specific (customer-specified) category (as
 // opposed to a Socrata-specific canonical category).
-case object DomainCategoryFieldType extends Countable with Rawable {
+case object DomainCategoryFieldType extends DocumentFieldType with Countable with Rawable {
   val fieldName: String = "customer_category"
 }
 
@@ -106,31 +109,31 @@ case object DomainCategoryFieldType extends Countable with Rawable {
 /////////////////////
 // Catalog Visibility
 
-case object IsCustomerDomainFieldType extends CeteraFieldType {
+case object IsCustomerDomainFieldType extends DomainFieldType {
   val fieldName: String = "is_customer_domain"
 }
 
-case object IsModerationEnabledFieldType extends CeteraFieldType {
+case object IsModerationEnabledFieldType extends DomainFieldType {
   val fieldName: String = "moderation_enabled"
 }
 
-case object IsRoutingApprovalEnabledFieldType extends CeteraFieldType {
+case object IsRoutingApprovalEnabledFieldType extends DocumentFieldType {
   val fieldName: String = "routing_approval_enabled"
 }
 
-case object IsDefaultViewFieldType extends CeteraFieldType {
+case object IsDefaultViewFieldType extends DocumentFieldType {
   val fieldName: String = "is_default_view"
 }
 
-case object IsModerationApprovedFieldType extends CeteraFieldType {
+case object IsModerationApprovedFieldType extends DocumentFieldType {
   val fieldName: String = "is_moderation_approved"
 }
 
-case object ApprovingDomainIdsFieldType extends CeteraFieldType {
+case object ApprovingDomainIdsFieldType extends DocumentFieldType {
   val fieldName: String = "approving_domain_ids"
 }
 
-case object SocrataIdDomainIdFieldType extends CeteraFieldType {
+case object SocrataIdDomainIdFieldType extends DocumentFieldType {
   val fieldName: String = "socrata_id.domain_id"
 }
 
@@ -140,7 +143,7 @@ case object SocrataIdDomainIdFieldType extends CeteraFieldType {
 
 // TODO: cetera-etl rename customer_tags to domain_tags
 // Domain tags are customer-defined tags (which surface as topics in the front end).
-case object DomainTagsFieldType extends Countable with Rawable {
+case object DomainTagsFieldType extends DocumentFieldType with Countable with Rawable {
   val fieldName: String = "customer_tags"
 }
 
@@ -149,7 +152,7 @@ case object DomainTagsFieldType extends Countable with Rawable {
 // own facets and call them whatever they like, for example you could define
 // Superheroes and select from a list of them. We support these fields as
 // direct url params (e.g., Superheros=Batman).
-case object DomainMetadataFieldType extends Mapable with Rawable {
+case object DomainMetadataFieldType extends DocumentFieldType with Mapable with Rawable {
   val fieldName: String = "customer_metadata_flattened"
 
   case object Key extends NestedField with Rawable {
@@ -165,27 +168,27 @@ case object DomainMetadataFieldType extends Mapable with Rawable {
 /////////////
 // Boostables
 
-case object TitleFieldType extends Boostable with Rawable {
+case object TitleFieldType extends DocumentFieldType with Boostable with Rawable {
   val fieldName: String = "indexed_metadata.name"
 }
 
-case object DescriptionFieldType extends Boostable {
+case object DescriptionFieldType extends DocumentFieldType with Boostable {
   val fieldName: String = "indexed_metadata.description"
 }
 
-case object ColumnNameFieldType extends Boostable {
+case object ColumnNameFieldType extends DocumentFieldType with Boostable {
   val fieldName: String = "indexed_metadata.columns_name"
 }
 
-case object ColumnDescriptionFieldType extends Boostable {
+case object ColumnDescriptionFieldType extends DocumentFieldType with Boostable {
   val fieldName: String = "indexed_metadata.columns_description"
 }
 
-case object ColumnFieldNameFieldType extends Boostable {
+case object ColumnFieldNameFieldType extends DocumentFieldType with Boostable {
   val fieldName: String = "indexed_metadata.columns_field_name"
 }
 
-case object DatatypeFieldType extends Boostable {
+case object DatatypeFieldType extends DocumentFieldType with Boostable {
   val fieldName: String = "datatype"
 }
 
@@ -193,26 +196,26 @@ case object DatatypeFieldType extends Boostable {
 //////////////
 // For sorting
 
-case object PageViewsTotalFieldType extends CeteraFieldType with Sortable {
+case object PageViewsTotalFieldType extends DocumentFieldType with Sortable {
   val fieldName: String = "page_views.page_views_total"
 }
 
-case object PageViewsLastMonthFieldType extends CeteraFieldType with Sortable {
+case object PageViewsLastMonthFieldType extends DocumentFieldType with Sortable {
   val fieldName: String = "page_views.page_views_last_month"
 }
 
-case object PageViewsLastWeekFieldType extends CeteraFieldType with Sortable {
+case object PageViewsLastWeekFieldType extends DocumentFieldType with Sortable {
   val fieldName: String = "page_views.page_views_last_week"
 }
 
-case object UpdatedAtFieldType extends CeteraFieldType with Sortable {
+case object UpdatedAtFieldType extends DocumentFieldType with Sortable {
   val fieldName: String = "updated_at" // notice the snake_case, long story
 }
 
-case object CreatedAtFieldType extends CeteraFieldType with Sortable {
+case object CreatedAtFieldType extends DocumentFieldType with Sortable {
   val fieldName: String = "created_at" // notice the snake_case, long story
 }
 
-case object NameFieldType extends CeteraFieldType with Sortable {
+case object NameFieldType extends DocumentFieldType with Sortable {
   val fieldName: String = "indexed_metadata.name.raw"
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/ElasticsearchBootstrap.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/ElasticsearchBootstrap.scala
@@ -66,7 +66,7 @@ object ElasticsearchBootstrap {
 
       } catch {
         case e: IndexAlreadyExistsException =>
-          logger.info(s"actually something went wrong ${e.getMessage}")
+          logger.info(s"actually that index ($indexAliasName) already exists!")
       }
     }
   }

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/JsonResponses.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/JsonResponses.scala
@@ -35,7 +35,7 @@ object JsonResponses {
 }
 
 // Helpers for internal timing information to report to the caller
-case class InternalTimings(serviceMillis: Long, searchMillis: Option[Long])
+case class InternalTimings(serviceMillis: Long, searchMillis: Seq[Long])
 
 object InternalTimings {
   implicit val jCodec = AutomaticJsonCodecBuilder[InternalTimings]

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/LogHelper.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/LogHelper.scala
@@ -12,7 +12,7 @@ object LogHelper {
       request.queryStr.getOrElse(""),
       "requested by",
       request.servletRequest.getRemoteHost,
-      s"""TIMINGS ## ESTime : ${timings.searchMillis.getOrElse(-1)} ## ServiceTime : ${timings.serviceMillis}"""
+      s"""TIMINGS ## ESTime : ${timings.searchMillis} ## ServiceTime : ${timings.serviceMillis}"""
     ).mkString(" -- ")
   }
 

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/BoostsSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/BoostsSpec.scala
@@ -47,9 +47,9 @@ class BoostsSpec extends WordSpec with ShouldMatchers {
   "boostDomains" should {
     "add domain cname boosts to the query" in {
       val query = QueryBuilders.functionScoreQuery(QueryBuilders.matchAllQuery)
-      val domainBoosts = Map[String, Float](
-        "example.com" -> 1.23f,
-        "data.seattle.gov" -> 4.56f
+      val domainBoosts = Map[Int, Float](
+        0 -> 1.23f,
+        7 -> 4.56f
       )
 
       Boosts.applyDomainBoosts(query, domainBoosts)
@@ -58,21 +58,11 @@ class BoostsSpec extends WordSpec with ShouldMatchers {
         "function_score": {
           "functions": [
             {
-              "filter": {
-                "has_parent": {
-                  "parent_type": "domain",
-                  "filter": { "term": { "domain_cname.raw": "example.com" } }
-                }
-              },
+              "filter": { "term": { "socrata_id.domain_id": 0 } },
               "weight": 1.23
             },
             {
-              "filter": {
-                "has_parent": {
-                  "parent_type": "domain",
-                  "filter": { "term": { "domain_cname.raw": "data.seattle.gov" } }
-                }
-              },
+              "filter": { "term": { "socrata_id.domain_id": 7 } },
               "weight": 4.56
             }
           ],
@@ -89,7 +79,7 @@ class BoostsSpec extends WordSpec with ShouldMatchers {
 
     "do nothing to the query if given no domain boosts" in {
       val query = QueryBuilders.functionScoreQuery(QueryBuilders.matchAllQuery)
-      val domainBoosts = Map.empty[String, Float]
+      val domainBoosts = Map.empty[Int, Float]
 
       val beforeJson = JsonReader.fromString(query.toString)
       Boosts.applyDomainBoosts(query, domainBoosts)

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -132,24 +132,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     "bool": {
       "should": [
         {"term": {"is_default_view": true}},
-        {"term": {"is_moderation_approved": true}},
-        {
-          "bool": {
-            "must": [
-              {"has_parent": {
-                "parent_type": "domain",
-                "filter": {
-                  "not": {
-                    "filter": {
-                      "term": {"moderation_enabled": true}
-                    }
-                  }
-                }
-              }},
-              {"not": {"filter": {"term": {"datatype": "datalens"} } } }
-            ]
-          }
-        }
+        {"term": {"is_moderation_approved": true}}
       ]
     }
   }"""

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -158,8 +158,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   }"""
 
   val defaultFilter = j"""{
-    "and": {
-      "filters": [
+    "bool": {
+      "must": [
         ${moderationFilter},
         ${routingApprovalFilter}
       ]
@@ -167,8 +167,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   }"""
 
   val defaultFilterPlusDomainIds = j"""{
-    "and": {
-      "filters": [
+    "bool": {
+      "must": [
         ${domainFilter},
         ${moderationFilter},
         ${routingApprovalFilter}
@@ -258,8 +258,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   }"""
 
   val complexFilter = j"""{
-    "and": {
-        "filters": [
+    "bool": {
+        "must": [
             ${datatypeDatasetsFilter},
             ${moderationFilter},
             ${routingApprovalFilter}
@@ -455,8 +455,32 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         |  "aggregations" : {
         |    "domain_filter" : {
         |      "filter" : {
-        |        "terms" : {
-        |          "socrata_id.domain_id" : [ ${domainId} ]
+        |        "bool" : {
+        |          "must" : [ {
+        |            "bool" : {
+        |              "should" : [ {
+        |                "term" : {
+        |                  "is_default_view" : true
+        |                }
+        |              }, {
+        |                "term" : {
+        |                  "is_moderation_approved" : true
+        |                }
+        |              } ]
+        |            }
+        |          }, {
+        |            "bool" : {
+        |              "must" : {
+        |                "bool" : {
+        |                  "should" : {
+        |                    "term" : {
+        |                      "is_approved_by_parent_domain" : true
+        |                    }
+        |                  }
+        |                }
+        |              }
+        |            }
+        |          } ]
         |        }
         |      },
         |      "aggregations" : {

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -331,7 +331,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         only = None,
         fieldBoosts = Map.empty,
         datatypeBoosts = Map.empty,
-        domainBoosts = Map.empty[String, Float],
+        domainIdBoosts = Map.empty[Int, Float],
         minShouldMatch = None,
         slop = None
       )
@@ -363,7 +363,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         only = None,
         fieldBoosts = Map.empty,
         datatypeBoosts = Map.empty,
-        domainBoosts = Map.empty[String, Float],
+        domainIdBoosts = Map.empty[Int, Float],
         minShouldMatch = None,
         slop = None
       )
@@ -395,7 +395,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         only = None,
         fieldBoosts = params.fieldBoosts,
         datatypeBoosts = Map.empty,
-        domainBoosts = Map.empty[String, Float],
+        domainIdBoosts = Map.empty[Int, Float],
         minShouldMatch = None,
         slop = None
       )
@@ -555,7 +555,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         only = params.only,
         fieldBoosts = Map.empty,
         datatypeBoosts = Map.empty,
-        domainBoosts = Map.empty[String, Float],
+        domainIdBoosts = Map.empty[Int, Float],
         minShouldMatch = None,
         slop = None,
         offset = params.offset,
@@ -610,7 +610,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         only = params.only,
         fieldBoosts = Map.empty,
         datatypeBoosts = Map.empty,
-        domainBoosts = Map.empty[String, Float],
+        domainIdBoosts = Map.empty[Int, Float],
         minShouldMatch = None,
         slop = None,
         offset = params.offset,

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -141,21 +141,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     "bool": {
       "must": {
         "bool": {
-          "should": [
-            {
-              "has_parent": {
-                "parent_type": "domain",
-                "filter": {
-                  "not": {
-                    "filter": {
-                      "term": {"routing_approval_enabled": true}
-                    }
-                  }
-                }
-              }
-            },
-            { "term": {"is_approved_by_parent_domain": true} }
-          ]
+          "should": { "term": {"is_approved_by_parent_domain": true} }
         }
       }
     }
@@ -275,7 +261,6 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     "and": {
         "filters": [
             ${datatypeDatasetsFilter},
-            ${domainFilter},
             ${moderationFilter},
             ${routingApprovalFilter}
         ]
@@ -312,7 +297,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     "construct a default match all query" in {
       val query = j"""{
         "filtered": {
-          "filter": ${defaultFilterPlusDomainIds},
+          "filter": ${defaultFilter},
           "query": ${matchAll}
         }
       }"""
@@ -421,6 +406,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
       }"""
 
       val expected = j"""{
+        "query": ${query},
         "aggregations": {
             "annotations": {
                 "aggregations": {

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
@@ -28,7 +28,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData with
         siteTitle = Some("Temporary URI"),
         moderationEnabled = false,
         routingApprovalEnabled = false)
-      val actualDomain = domainClient.find("petercetera.net")
+      val (actualDomain, _) = domainClient.find("petercetera.net")
       actualDomain.get should be(expectedDomain)
     }
 
@@ -41,19 +41,19 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData with
         siteTitle = Some("And other things"),
         moderationEnabled = true,
         routingApprovalEnabled = false)
-      val actualDomain = domainClient.find("opendata-demo.socrata.com")
+      val (actualDomain, _) = domainClient.find("opendata-demo.socrata.com")
       actualDomain.get should be(expectedDomain)
     }
 
     "return None if the domain does not exist" in {
       val expectedDomain = None
-      val actualDomain = domainClient.find("hellcat.com")
+      val (actualDomain, _) = domainClient.find("hellcat.com")
       actualDomain should be(expectedDomain)
     }
 
     "return None if searching for blank string" in {
       val expectedDomain = None
-      val actualDomain = domainClient.find("")
+      val (actualDomain, _) = domainClient.find("")
       actualDomain should be(expectedDomain)
     }
   }

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
@@ -50,5 +50,11 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData with
       val actualDomain = domainClient.find("hellcat.com")
       actualDomain should be(expectedDomain)
     }
+
+    "return None if searching for blank string" in {
+      val expectedDomain = None
+      val actualDomain = domainClient.find("")
+      actualDomain should be(expectedDomain)
+    }
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
@@ -14,7 +14,7 @@ class CountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAll
   val testSuiteName = getClass.getSimpleName.toLowerCase
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
   val domainClient: DomainClient = new DomainClient(client, testSuiteName)
-  val documentClient: DocumentClient = new DocumentClient(client, testSuiteName, None, None, Set.empty)
+  val documentClient: DocumentClient = new DocumentClient(client, domainClient, testSuiteName, None, None, Set.empty)
   val service: CountService = new CountService(documentClient, domainClient)
 
   override protected def afterAll(): Unit = {
@@ -113,7 +113,7 @@ class CountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAll
 class CountServiceSpecWithTestESData extends FunSuiteLike with Matchers with BeforeAndAfterAll with TestESData {
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
   val domainClient: DomainClient = new DomainClient(client, testSuiteName)
-  val documentClient: DocumentClient = new DocumentClient(client, testSuiteName, None, None, Set.empty)
+  val documentClient: DocumentClient = new DocumentClient(client, domainClient, testSuiteName, None, None, Set.empty)
   val service: CountService = new CountService(documentClient, domainClient)
 
   override protected def beforeAll(): Unit = {

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
@@ -15,7 +15,7 @@ class DatatypeBoostSpec extends FunSuiteLike with Matchers with TestESData with 
 
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
   val domainClient: DomainClient = new DomainClient(client, testSuiteName)
-  val documentClient: DocumentClient = new DocumentClient(client, testSuiteName, None, None, Set.empty)
+  val documentClient: DocumentClient = new DocumentClient(client, domainClient, testSuiteName, None, None, Set.empty)
   val balboaClient: BalboaClient = new BalboaClient("/tmp/metrics")
   val service: SearchService = new SearchService(documentClient, domainClient, balboaClient)
 
@@ -30,6 +30,8 @@ class DatatypeBoostSpec extends FunSuiteLike with Matchers with TestESData with 
 
   test("datatype boost - increases score when datatype matches") {
     val (results, _) = service.doSearch(Map(
+      Params.context -> "petercetera.net",
+      Params.filterDomains -> "petercetera.net,opendata-demo.socrata.com,blue.org,annabelle.island.net",
       Params.querySimple -> "one",
       Params.showScore -> "true",
       boostedDatatypeQueryString -> "10"

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
@@ -39,7 +39,11 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
 
   test("domain boost of 0.5 should not produce top result") {
     activeDomainCnames.foreach { domain =>
-      val (results, _) = service.doSearch(Map(s"""boostDomains[${domain}]""" -> "0.5").mapValues(Seq(_)))
+      val (results, _) = service.doSearch(Map(
+        Params.showScore -> "true",
+        Params.context -> domain,
+        Params.filterDomains -> activeDomainCnames.mkString(","),
+        s"""boostDomains[${domain}]""" -> "0.5").mapValues(Seq(_)))
       results.results.head.metadata(esDomainType) shouldNot be(JString(domain))
     }
   }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/DomainCountServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/DomainCountServiceSpec.scala
@@ -20,11 +20,11 @@ class DomainCountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAf
     client.close()
   }
 
-  test("count domains with search context") {
+  test("count domains from unmoderated search context") {
     val expectedResults = List(
-      Count("annabelle.island.net", 0),
+      Count("annabelle.island.net", 1),
       Count("blue.org", 1),
-      Count("opendata-demo.socrata.com", 0),
+      Count("opendata-demo.socrata.com", 1),
       Count("petercetera.net", 4))
     val (res, _) = service.doAggregate(Map(
       Params.context -> "petercetera.net",
@@ -33,9 +33,22 @@ class DomainCountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAf
     res.results should contain theSameElementsAs expectedResults
   }
 
+  test("count domains from moderated search context") {
+    val expectedResults = List(
+      Count("annabelle.island.net", 1),
+      Count("blue.org", 0),
+      Count("opendata-demo.socrata.com", 1),
+      Count("petercetera.net", 1))
+    val (res, _) = service.doAggregate(Map(
+      Params.context -> "annabelle.island.net",
+      Params.filterDomains -> "petercetera.net,opendata-demo.socrata.com,blue.org,annabelle.island.net")
+      .mapValues(Seq(_)))
+    res.results should contain theSameElementsAs expectedResults
+  }
+
   test("count domains default to include only customer domains") {
     val expectedResults = List(
-      Count("annabelle.island.net", 0),
+      Count("annabelle.island.net", 1),
       Count("blue.org", 1),
       // opendata-demo.socrata.com is not a customer domain, so the domain and all docs should be hidden
       // Count("opendata-demo.socrata.com", 0),

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/DomainCountServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/DomainCountServiceSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.{BeforeAndAfterAll, Matchers, FunSuiteLike}
 import com.socrata.cetera.{TestESData, TestESClient}
 import com.socrata.cetera.search._
 import com.socrata.cetera.types.Count
+import com.socrata.cetera.util.Params
 
 class DomainCountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAll with TestESData {
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
@@ -24,19 +25,13 @@ class DomainCountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAf
     val expectedResults = List(
       Count("annabelle.island.net", 0),
       Count("blue.org", 1),
-      Count("opendata-demo.socrata.com", 0),
+      // opendata-demo.socrata.com is not a customer domain, so the domain and all docs should be hidden
+      // Count("opendata-demo.socrata.com", 0),
       Count("petercetera.net", 4))
-    val (res, _) = service.doAggregate(Map())
+    val (res, _) = service.doAggregate(Map(
+      Params.context -> "petercetera.net",
+      Params.filterDomains -> "petercetera.net,opendata-demo.socrata.com,blue.org,annabelle.island.net")
+      .mapValues(Seq(_)))
     res.results should contain theSameElementsAs expectedResults
-  }
-
-  test("only count publicly visible documents") {
-    val (res, _) = service.doAggregate(Map())
-    res.results.foreach { count =>
-      // opendata-demo.socrata.com is not a customer domain, so all docs should be hidden
-      if (count.thing == JString("opendata-demo.socrata.com")) {
-        count.count should be(JNumber(0))
-      }
-    }
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
@@ -9,7 +9,7 @@ import com.socrata.cetera.{TestESClient, TestESData}
 class FacetServiceSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
   val domainClient: DomainClient = new DomainClient(client, testSuiteName)
-  val documentClient: DocumentClient = new DocumentClient(client, testSuiteName, None, None, Set.empty)
+  val documentClient: DocumentClient = new DocumentClient(client, domainClient, testSuiteName, None, None, Set.empty)
   val service: FacetService = new FacetService(documentClient, domainClient)
 
   override protected def beforeAll(): Unit = {

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
@@ -26,7 +26,7 @@ class FacetServiceSpec extends FunSuiteLike with Matchers with TestESData with B
   test("retrieve all visible domain facets") {
     val (datatypes, categories, tags, facets) = domainCnames.map { cname =>
       val (facets, timings) = service.doAggregate(cname)
-      timings.searchMillis should be('defined)
+      timings.searchMillis.headOption should be('defined)
 
       val datatypes = facets.find(_.facet == "datatypes").map(_.values).getOrElse(fail())
       val categories = facets.find(_.facet == "categories").map(_.values).getOrElse(fail())

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
@@ -1,9 +1,11 @@
 package com.socrata.cetera.services
 
+import scala.collection.mutable.ArrayBuffer
+
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
 
 import com.socrata.cetera.search._
-import com.socrata.cetera.types.{Datatypes, FacetCount, ValueCount}
+import com.socrata.cetera.types.{FacetCount, ValueCount}
 import com.socrata.cetera.{TestESClient, TestESData}
 
 class FacetServiceSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
@@ -21,7 +23,7 @@ class FacetServiceSpec extends FunSuiteLike with Matchers with TestESData with B
     client.close()
   }
 
-  test("retrieve all domain facets") {
+  test("retrieve all visible domain facets") {
     val (datatypes, categories, tags, facets) = domainCnames.map { cname =>
       val (facets, timings) = service.doAggregate(cname)
       timings.searchMillis should be('defined)
@@ -34,24 +36,51 @@ class FacetServiceSpec extends FunSuiteLike with Matchers with TestESData with B
       (b, x) => (b._1 ++ x._1, b._2 ++ x._2, b._3 ++ x._3, b._4 ++ x._4)
     }
 
-    Datatypes.materialized.foreach { dt =>
-      datatypes.find(_.value == dt.singular) should be('defined)
-    }
+    val expectedDatatypes = List(
+      ValueCount("calendar", 1),
+      ValueCount("dataset", 1),
+      ValueCount("file", 1),
+      ValueCount("href", 1),
+      ValueCount("chart", 1),
+      ValueCount("story", 1),
+      ValueCount("dataset", 1))
+    datatypes should contain theSameElementsAs expectedDatatypes
 
+    val expectedCategories = List(
+      ValueCount("Alpha", 3),
+      ValueCount("Fun", 1),
+      ValueCount("Beta", 1),
+      ValueCount("Gamma", 1),
+      ValueCount("Fun", 1))
     categories.find(_.value == "") shouldNot be('defined)
-    domainCategories.distinct.filter(_.nonEmpty).foreach { cat =>
-      categories.find(_.value == cat) should be('defined)
-    }
+    categories should contain theSameElementsAs expectedCategories
 
+    val expectedTags = List(
+      ValueCount("1-one", 3),
+      ValueCount("2-two", 1),
+      ValueCount("3-three", 1))
     tags.find(_.value == "") shouldNot be('defined)
-    domainTags.flatten.distinct.filter(_.nonEmpty).foreach { tag =>
-      tags.find(_.value == tag) should be('defined)
-    }
+    tags should contain theSameElementsAs expectedTags
 
-    domainMetadata.flatMap(_.keys).distinct.foreach { key =>
-      val facet = facets.find(_.facet == key)
-      facet should be('defined)
-      facet.get.count should be(facet.get.values.map(_.count).sum)
-    }
+    val expectedFacets = List(
+      FacetCount("datatypes", 4, ArrayBuffer(ValueCount("calendar", 1), ValueCount("dataset", 1), ValueCount("file", 1), ValueCount("href", 1))),
+      FacetCount("categories", 4, ArrayBuffer(ValueCount("Alpha", 3), ValueCount("Fun", 1))),
+      FacetCount("tags", 3, ArrayBuffer(ValueCount("1-one", 3))),
+      FacetCount("five", 3, ArrayBuffer(ValueCount("8", 3))),
+      FacetCount("one", 3, ArrayBuffer(ValueCount("1", 3))),
+      FacetCount("two", 3, ArrayBuffer(ValueCount("3", 3))),
+      FacetCount("datatypes", 1, ArrayBuffer(ValueCount("chart", 1))),
+      FacetCount("categories", 1, ArrayBuffer(ValueCount("Beta", 1))),
+      FacetCount("tags", 1, ArrayBuffer(ValueCount("2-two", 1))),
+      FacetCount("one", 1, ArrayBuffer(ValueCount("2", 1))),
+      FacetCount("datatypes", 1, ArrayBuffer(ValueCount("story", 1))),
+      FacetCount("categories", 1, ArrayBuffer(ValueCount("Gamma", 1))),
+      FacetCount("tags", 1, ArrayBuffer(ValueCount("3-three", 1))),
+      FacetCount("two", 1, ArrayBuffer(ValueCount("3", 1))),
+      FacetCount("datatypes", 1, ArrayBuffer(ValueCount("dataset", 1))),
+      FacetCount("categories", 1, ArrayBuffer(ValueCount("Fun", 1))),
+      FacetCount("tags", 0, ArrayBuffer()))
+    facets should contain theSameElementsAs expectedFacets
+    facets.foreach(f => f.count should be(f.values.map(_.count).sum))
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -25,7 +25,7 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
   val testSuiteName: String = getClass.getSimpleName.toLowerCase
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
   val domainClient: DomainClient = new DomainClient(client, testSuiteName)
-  val documentClient: DocumentClient = new DocumentClient(client, testSuiteName, None, None, Set.empty)
+  val documentClient: DocumentClient = new DocumentClient(client, domainClient, testSuiteName, None, None, Set.empty)
   val balboaClient: BalboaClient = new BalboaClient("/tmp/metrics")
   val service: SearchService = new SearchService(documentClient, domainClient, balboaClient)
 
@@ -224,7 +224,7 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
 class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
   val client: ElasticSearchClient = new TestESClient(testSuiteName)
   val domainClient: DomainClient = new DomainClient(client, testSuiteName)
-  val documentClient: DocumentClient = new DocumentClient(client, testSuiteName, None, None, Set.empty)
+  val documentClient: DocumentClient = new DocumentClient(client, domainClient, testSuiteName, None, None, Set.empty)
   val balboaDir: java.io.File = new java.io.File("balboa_test_trash")
   val balboaClient: BalboaClient = new BalboaClient(balboaDir.getName)
   val service: SearchService = new SearchService(documentClient, domainClient, balboaClient)

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -312,7 +312,7 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
     /*
       Test Data domains -> documents
       id  cname                     cust  mod   r&a
-      0   petercetera.net           t     f     f
+      0   petercetera.net           t     f     f (not moderated, 1 default view)
         documents
         fxf     def mod r&a visible
         fxf-0   f   f   0   t
@@ -324,7 +324,7 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
         fxf-1   f   t   2   f / t
         fxf-5   f   f   3   f / f
         fxf-9   f   n   0   f / f
-      2   blue.org                  t     f     t
+      2   blue.org                  t     f     t (not moderated, 0 default views)
         fxf     def mod r&a visible
         fxf-2   f   n   3   f
         fxf-6   f   t   0   f

--- a/cetera-perf/src/main/scala/com/socrata/cetera/CatalogSearchBenchmark.scala
+++ b/cetera-perf/src/main/scala/com/socrata/cetera/CatalogSearchBenchmark.scala
@@ -30,6 +30,7 @@ class CatalogSearchBenchmark {
   val domainClient = new DomainClient(client, config.elasticSearch.indexAliasName)
   val documentClient = new DocumentClient(
     client,
+    domainClient,
     config.elasticSearch.indexAliasName,
     config.elasticSearch.titleBoost,
     config.elasticSearch.minShouldMatch,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -38,8 +38,8 @@ object CeteraBuild extends Build {
     file("./cetera-http/"),
     settings = commonSettings ++ de.johoop.jacoco4sbt.JacocoPlugin.jacoco.settings ++ Seq(
       // Make sure the "configs" dir is on the runtime classpaths so application.conf can be found.
-      fullClasspath in Runtime <+= baseDirectory map { d => Attributed.blank(d / "configs") },
-      fullClasspath in Test <+= baseDirectory map { d => Attributed.blank(d / "configs") },
+      fullClasspath in Runtime <+= baseDirectory map { d => Attributed.blank(d.getParentFile / "configs") },
+      fullClasspath in Test <+= baseDirectory map { d => Attributed.blank(d.getParentFile / "configs") },
       buildInfoPackage := "com.socrata.cetera",
       libraryDependencies ++= Deps.http
     )


### PR DESCRIPTION
**what it do**
* remove has_parent filters from all the things
  * perf: these changes improve response time by ~ 80%
* query requests will still use a has_parent scored query
  * because we don't want to duplicate all of lucene scoring in cetera

**depends on** #134 
**replaces** #135

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata/cetera/136)
<!-- Reviewable:end -->
