### PR TITLE
EN-4107 datalens standalone viz moderation filter

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -106,7 +106,10 @@ object DocumentFilters {
     val parentDomainIsModerated = domainIdsFilter(moderatedDomainIds, aggPrefix)
     val parentDomainIsNotModerated = domainIdsFilter(unmoderatedDomainIds, aggPrefix)
 
-    val datalensUniqueAndSpecialSnowflakeFilter = datatypeFilter(Seq(TypeDatalenses.singular), aggPrefix)
+    val datalensUniqueAndSpecialSnowflakeFilter = datatypeFilter(
+      Seq(TypeDatalenses.singular, TypeDatalensCharts.singular, TypeDatalensMaps.singular),
+      aggPrefix
+    )
     val documentIsNotDatalens = notFilter(datalensUniqueAndSpecialSnowflakeFilter)
 
     val basicFilter = boolFilter()

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
@@ -323,6 +323,16 @@ trait TestESData {
         Map.empty,
         isPublic = false, isDefaultView = true, Some(true), Seq(0, 1, 2,3), isApprovedByParentDomain = true,
         "42", "Private", Seq.empty, 0L
+      )),
+      (0, buildEsDoc(
+        "zeta-0004", 0,
+        "standalone visualization", "zeta-0004", DateTime.now.toString, DateTime.now.toString,
+        "zeta-0004", Seq.empty, "", Map.empty, Map.empty,
+        TypeDatalensCharts.singular, viewtype = "", 0F,
+        "", "", Seq.empty, Seq.empty, Seq.empty,
+        Map.empty,
+        isPublic = true, isDefaultView = false, None, Seq(0, 1, 2,3), isApprovedByParentDomain = true,
+        "42", "Standalone", Seq.empty, 0L
       ))
     ).foreach { case (domain, doc) =>
       client.client.prepareIndex(testSuiteName, esDocumentType)

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESDataSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESDataSpec.scala
@@ -48,7 +48,7 @@ class TestESDataSpec extends FunSuiteLike with Matchers with TestESData with Bef
 
   test("test docs are bootstrapped") {
     val res = client.client.prepareSearch().execute.actionGet
-    val numDocs = Datatypes.materialized.length + 3
+    val numDocs = Datatypes.materialized.length + 4
     val numDomains = domainCnames.length
     res.getHits.getTotalHits should be(numDocs + numDomains)
   }

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -509,7 +509,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         |                    "not" : {
         |                      "filter" : {
         |                        "terms" : {
-        |                          "datatype" : [ "datalens" ]
+        |                          "datatype" : [ "datalens", "datalens_chart", "datalens_map" ]
         |                        }
         |                      }
         |                    }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -321,6 +321,7 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
         fxf-8   t   n   3         t
         zeta-1  f   t   0         t       (mod=t anomaly)
         zeta-3  t   t   0,1,2,3   f       (isPublic=false)
+        zeta-4  f   n   0,1,2,3   f       (unapproved datalens_chart/map should not be visible)
       1   opendata-demo.socrata.com f     t     f (not customer domain)
         fxf     def mod r&a visible
         fxf-1   f   t   2   f / t


### PR DESCRIPTION
datalens and datalens_chart and datalens_map are all considered datalenses
and must obey the unique and special snowflake for view_moderation_status.

Paired-with: Robert.Voyer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socrata/cetera/138)
<!-- Reviewable:end -->
