### PR TITLE
Jason/distinguish all domains from no domains

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -6,8 +6,7 @@ import org.elasticsearch.index.query.QueryBuilders
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.search.DomainAggregations._
-import com.socrata.cetera.search.DomainFilters._
+import com.socrata.cetera.search.DomainFilters.{domainIdsFilter, isCustomerDomainFilter}
 import com.socrata.cetera.types.{Domain, DomainCnameFieldType, QueryType}
 import com.socrata.cetera.util.{JsonDecodeException, LogHelper}
 
@@ -51,11 +50,33 @@ class DomainClient(val esClient: ElasticSearchClient, val indexAliasName: String
   }
 
   // if domain cname filter is provided limit to that scope, otherwise default to publicly visible domains
-  def findRelevantDomains(searchContextCname: Option[String], domainCnames: Set[String]): (Set[Domain], Long) = {
-    searchContextCname.foldLeft(domainCnames) { (b, x) => b + x } match {
-      case cs: Set[String] if cs.nonEmpty => find(cs)
-      case _ => customerDomainSearch
+  // also looks up the search context and throws if it cannot be found
+  def findRelevantDomains(
+      searchContextCname: Option[String],
+      domainCnames: Option[Set[String]])
+    : (Option[Domain], Option[Set[Domain]], Long) = {
+
+    // We want to fetch all relevant domains (search context and query domains) in a single query
+    val (foundDomains, timings) = domainCnames match {
+      case Some(cnames) => find(domainCnames.getOrElse(Set.empty[String]) ++ searchContextCname)
+      case None => customerDomainSearch
     }
+
+    // If a searchContext is specified and we can't find it, we have to bail
+    val searchContextDomain = searchContextCname.flatMap(cname => foundDomains.find(_.domainCname == cname))
+    searchContextCname.foreach { searchContext =>
+      if (!foundDomains.exists(_.domainCname == searchContext)) {
+        throw new DomainNotFound(searchContext)
+      }
+    }
+
+    // None means none were specified; Set.empty means none could be found
+    val foundQueryDomains = domainCnames match {
+      case Some(cnames) => Some(cnames.flatMap(cname => foundDomains.find(_.domainCname == cname)))
+      case None => Some(foundDomains)
+    }
+
+    (searchContextDomain, foundQueryDomains, timings)
   }
 
   // TODO: handle unlimited domain count with aggregation or scan+scroll query
@@ -89,27 +110,41 @@ class DomainClient(val esClient: ElasticSearchClient, val indexAliasName: String
     (ids, mod, unmod, raOff)
   }
 
+  // NOTE: I do not currently honor counting according to parameters
   def buildCountRequest(
-      searchQuery: QueryType,
-      searchDomains: Set[Domain],
-      searchContext: Option[Domain],
-      categories: Option[Set[String]],
-      tags: Option[Set[String]],
-      only: Option[Seq[String]])
+      domains: Option[Set[Domain]],
+      searchContext: Option[Domain])
     : SearchRequestBuilder = {
-    val (domainsFilter, domainsAggregation) = {
-      val contextMod = searchContext.exists(_.moderationEnabled)
-      val (ids, mod, unmod, raOff) = calculateIdsAndModRAStatuses(searchDomains)
-      val dsFilter = if (ids.nonEmpty) domainIds(ids) else isCustomerDomainFilter
-      val dsAggregation = domains(contextMod, mod, unmod, raOff)
-      (dsFilter, dsAggregation)
+
+    val contextModerated = searchContext.exists(_.moderationEnabled)
+
+    val (domainIds,
+         moderatedDomainIds,
+         unmoderatedDomainIds,
+         routingApprovalDisabledDomainIds) = domains match {
+      case Some(ds) => calculateIdsAndModRAStatuses(ds)
+      case None => (Set.empty[Int], Set.empty[Int], Set.empty[Int], Set.empty[Int])
     }
+
+    val domainFilter = domains match {
+      case Some(ds) => domainIdsFilter(domainIds)
+      case None => isCustomerDomainFilter
+    }
+
+    val aggregation = DomainAggregations.domains(
+      contextModerated,
+      moderatedDomainIds,
+      unmoderatedDomainIds,
+      routingApprovalDisabledDomainIds
+    )
+
     esClient.client.prepareSearch(indexAliasName).setTypes(esDomainType)
-      .setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), domainsFilter))
-      .addAggregation(domainsAggregation)
+      .setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), domainFilter))
+      .addAggregation(aggregation)
       .setSearchType(SearchType.COUNT)
       .setSize(0) // no docs, aggs only
   }
 }
 
+// Should throw when Search Context is not found
 class DomainNotFound(cname: String) extends NoSuchElementException(cname)

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -7,13 +7,13 @@ import com.rojoma.json.v3.codec.DecodeError
 import com.rojoma.json.v3.io.JsonReader
 import com.rojoma.json.v3.matcher.{FirstOf, PObject, Variable}
 import com.socrata.http.server.implicits._
-import com.socrata.http.server.responses.{BadRequest, InternalServerError, Json, OK}
+import com.socrata.http.server.responses.{BadRequest, InternalServerError, Json, NotFound, OK}
 import com.socrata.http.server.routing.SimpleResource
 import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.search.{DocumentClient, DomainClient}
+import com.socrata.cetera.search.{DocumentClient, DomainClient, DomainNotFound}
 import com.socrata.cetera.types._
 import com.socrata.cetera.util.JsonResponses.jsonError
 import com.socrata.cetera.util._
@@ -96,6 +96,10 @@ class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
       case e: IllegalArgumentException =>
         logger.info(e.getMessage)
         BadRequest ~> HeaderAclAllowOriginAll ~> jsonError(e.getMessage)
+      case DomainNotFound(e) =>
+        val msg = s"Domain not found: $e"
+        logger.error(msg)
+        NotFound ~> HeaderAclAllowOriginAll ~> jsonError(msg)
       case NonFatal(e) =>
         val esError = ElasticsearchError(e)
         logger.error(s"Database error: ${esError.getMessage}")

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/DomainCountService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/DomainCountService.scala
@@ -7,13 +7,13 @@ import com.rojoma.json.v3.codec.DecodeError
 import com.rojoma.json.v3.io.JsonReader
 import com.rojoma.json.v3.matcher.{PObject, Variable}
 import com.socrata.http.server.implicits._
-import com.socrata.http.server.responses.{BadRequest, InternalServerError, Json, OK}
+import com.socrata.http.server.responses.{BadRequest, InternalServerError, Json, NotFound, OK}
 import com.socrata.http.server.routing.SimpleResource
 import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.search.DomainClient
+import com.socrata.cetera.search.{DomainClient, DomainNotFound}
 import com.socrata.cetera.types.Count
 import com.socrata.cetera.util.JsonResponses.jsonError
 import com.socrata.cetera.util._
@@ -78,6 +78,10 @@ class DomainCountService(domainClient: DomainClient) {
       case e: IllegalArgumentException =>
         logger.info(e.getMessage)
         BadRequest ~> HeaderAclAllowOriginAll ~> jsonError(e.getMessage)
+      case DomainNotFound(e) =>
+        val msg = s"Domain not found: $e"
+        logger.error(msg)
+        NotFound ~> HeaderAclAllowOriginAll ~> jsonError(msg)
       case NonFatal(e) =>
         val esError = ElasticsearchError(e)
         logger.error(s"Database error: ${esError.getMessage}")

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/FacetService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/FacetService.scala
@@ -4,7 +4,7 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 import com.socrata.http.server.implicits._
-import com.socrata.http.server.responses.{BadRequest, InternalServerError, Json, OK}
+import com.socrata.http.server.responses.{BadRequest, InternalServerError, Json, NotFound, OK}
 import com.socrata.http.server.routing.SimpleResource
 import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import org.elasticsearch.search.aggregations.bucket.filter.Filter
@@ -37,6 +37,10 @@ class FacetService(documentClient: DocumentClient, domainClient: DomainClient) {
           logger.info(LogHelper.formatRequest(req, timings))
           OK ~> HeaderAclAllowOriginAll ~> Json(facets)
         } catch {
+          case DomainNotFound(e) =>
+            val msg = s"Domain not found: $e"
+            logger.error(msg)
+            NotFound ~> HeaderAclAllowOriginAll ~> jsonError(msg)
           case NonFatal(e) =>
             val esError = ElasticsearchError(e)
             logger.error(s"Database error: ${esError.getMessage}")

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/JsonResponses.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/JsonResponses.scala
@@ -8,11 +8,6 @@ import com.socrata.http.server.HttpResponse
 import com.socrata.http.server.responses.Json
 
 object JsonResponses {
-  def jsonMessage(message: String): HttpResponse = {
-    val messageMap = Map("message" -> message)
-    Json(messageMap)
-  }
-
   def jsonError(error: String): HttpResponse = {
     val errorMap = Map("error" -> error)
     Json(errorMap)

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/QueryParametersParser.scala
@@ -8,7 +8,7 @@ import com.socrata.cetera.types._
 // These are validated input parameters but aren't supposed to know anything about ES
 case class ValidatedQueryParameters(
     searchQuery: QueryType,
-    domains: Set[String],
+    domains: Option[Set[String]],
     domainMetadata: Option[Set[(String, String)]],
     searchContext: Option[String],
     categories: Option[Set[String]],
@@ -123,11 +123,11 @@ object QueryParametersParser {
     )
   }
 
-  def prepareDomains(queryParameters: MultiQueryParams): Set[String] = {
-    queryParameters.first(Params.filterDomains) match {
-      case Some(ds) => ds.toLowerCase.split(filterDelimiter).toSet
-      case None => Set.empty[String]
-    }
+  // Still uses old-style comma-separation
+  def prepareDomains(queryParameters: MultiQueryParams): Option[Set[String]] = {
+    queryParameters.first(Params.filterDomains).map(domain =>
+      domain.toLowerCase.split(filterDelimiter).toSet
+    )
   }
 
   def prepareSearchContext(queryParameters: MultiQueryParams): Option[String] = {

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -157,6 +157,14 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     }
   }"""
 
+  // NOTE: In reality, the domain_id set would be populated or no results would come back.
+  // But, when domains is empty, this filter must match no (rather than all) domain_ids.
+  // See instances of `domains = Set.empty[Domain]`
+  val domainIdsFilterEmpty = j"""{
+    "terms" : { "socrata_id.domain_id" : [] }
+  }"""
+
+
   val publicFilter = j"""{
     "not": {
       "filter": {
@@ -168,6 +176,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   val defaultFilter = j"""{
     "bool": {
       "must": [
+        ${domainIdsFilterEmpty},
         ${publicFilter},
         ${moderationFilter},
         ${routingApprovalFilter}
@@ -271,6 +280,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     "bool": {
         "must": [
             ${datatypeDatasetsFilter},
+            ${domainIdsFilterEmpty},
             ${publicFilter},
             ${moderationFilter},
             ${routingApprovalFilter}
@@ -319,7 +329,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
       val request = documentClient.buildBaseRequest(
         searchQuery = NoQuery,
-        domains = None,
+        domains = Set.empty[Domain],
         searchContext = None,
         categories = None,
         tags = None,
@@ -351,7 +361,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
       val request = documentClient.buildBaseRequest(
         searchQuery = params.searchQuery,
-        domains = None,
+        domains = Set.empty[Domain],
         searchContext = None,
         categories = None,
         tags = None,
@@ -383,7 +393,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
       val request = documentClient.buildBaseRequest(
         searchQuery = params.searchQuery,
-        domains = None,
+        domains = Set.empty[Domain],
         searchContext = None,
         categories = None,
         tags = None,
@@ -440,7 +450,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
       val request = documentClient.buildCountRequest(
         CategoriesFieldType,
         searchQuery = params.searchQuery,
-        domains = None,
+        domains = Set.empty[Domain],
         searchContext = None,
         categories = params.categories,
         tags = params.tags,
@@ -610,7 +620,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
       val request = documentClient.buildSearchRequest(
         searchQuery = params.searchQuery,
-        domains = None,
+        domains = Set.empty[Domain],
         searchContext = None,
         categories = params.categories,
         tags = params.tags,
@@ -665,7 +675,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
       val request = documentClient.buildSearchRequest(
         searchQuery = NoQuery,
-        domains = None,
+        domains = Set.empty[Domain],
         searchContext = None,
         categories = params.categories,
         tags = params.tags,

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -52,7 +52,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   val domainIds = Set(1, 2, 3)
   val params = ValidatedQueryParameters(
     searchQuery = SimpleQuery("search query terms"),
-    domains = Set("www.example.com", "test.example.com", "socrata.com"),
+    domains = Some(Set("www.example.com", "test.example.com", "socrata.com")),
     domainMetadata = None,
     searchContext = None,
     categories = Some(Set("Social Services", "Environment", "Housing & Development")),
@@ -319,7 +319,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
       val request = documentClient.buildBaseRequest(
         searchQuery = NoQuery,
-        domains = Set.empty,
+        domains = None,
         searchContext = None,
         categories = None,
         tags = None,
@@ -351,7 +351,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
       val request = documentClient.buildBaseRequest(
         searchQuery = params.searchQuery,
-        domains = Set.empty,
+        domains = None,
         searchContext = None,
         categories = None,
         tags = None,
@@ -383,7 +383,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
       val request = documentClient.buildBaseRequest(
         searchQuery = params.searchQuery,
-        domains = Set.empty,
+        domains = None,
         searchContext = None,
         categories = None,
         tags = None,
@@ -440,7 +440,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
       val request = documentClient.buildCountRequest(
         CategoriesFieldType,
         searchQuery = params.searchQuery,
-        domains = Set.empty,
+        domains = None,
         searchContext = None,
         categories = params.categories,
         tags = params.tags,
@@ -610,7 +610,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
       val request = documentClient.buildSearchRequest(
         searchQuery = params.searchQuery,
-        domains = Set.empty,
+        domains = None,
         searchContext = None,
         categories = params.categories,
         tags = params.tags,
@@ -665,7 +665,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
       val request = documentClient.buildSearchRequest(
         searchQuery = NoQuery,
-        domains = Set.empty,
+        domains = None,
         searchContext = None,
         categories = params.categories,
         tags = params.tags,

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
@@ -71,4 +71,30 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData with
       actualDomain shouldBe Some(expectedDomain)
     }
   }
+
+  "findRelevantDomains" should {
+    "throw DomainNotFound exception when searchContext is missing" in {
+      intercept[DomainNotFound] {
+        domainClient.findRelevantDomains(Some("iamnotarealdomain.wat"), None)
+      }
+    }
+
+    "throw DomainNotFound exception when searchContext is missing even if domains are found" in {
+      intercept[DomainNotFound] {
+        domainClient.findRelevantDomains(Some("iamnotarealdomain.wat"), Some(Set("dylan.demo.socrata.com")))
+      }
+    }
+
+    "not throw DomainNotFound exception when searchContext is present" in {
+      noException should be thrownBy {
+        domainClient.findRelevantDomains(Some("dylan.demo.socrata.com"), None)
+      }
+    }
+
+    "not throw DomainNotFound exception when domains are missing" in {
+      noException should be thrownBy {
+        domainClient.findRelevantDomains(None, Some(Set("iamnotarealdomain.wat")))
+      }
+    }
+  }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -343,7 +343,7 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
     //   * rejected and pending views don't show up regardless of domain setting
     //   * that the ES type returned includes only documents (i.e. no domains)
     //   * that non-customer domains don't show up
-    val (res, _) = service.doSearch(Map.empty)
+    val (res, _) = service.doSearch(Map("pants" -> Seq.empty[String])) // Jason debugging
     val actualFxfs = res.results.map(_.resource.dyn.id.!.asInstanceOf[JString].string)
     actualFxfs should contain theSameElementsAs expectedFxfs
   }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -343,7 +343,7 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
     //   * rejected and pending views don't show up regardless of domain setting
     //   * that the ES type returned includes only documents (i.e. no domains)
     //   * that non-customer domains don't show up
-    val (res, _) = service.doSearch(Map("pants" -> Seq.empty[String])) // Jason debugging
+    val (res, _) = service.doSearch(Map.empty)
     val actualFxfs = res.results.map(_.resource.dyn.id.!.asInstanceOf[JString].string)
     actualFxfs should contain theSameElementsAs expectedFxfs
   }


### PR DESCRIPTION
This fixes a bug wherein if you specified a list of domains and none of them could be found, instead of getting no results, you'd get back a whole bunch of results.