### PR TITLE
Katie/en 4588/add airbrake

### DIFF
--- a/cetera-http/docker/cetera.conf.j2
+++ b/cetera-http/docker/cetera.conf.j2
@@ -13,8 +13,14 @@ com.socrata {
   }
 
   log4j {
-    rootLogger = [ INFO, stdout ]
+    rootLogger = {{ LOG_PATHS }}
     appender {
+      airbrake.class = airbrake.AirbrakeAppender
+      airbrake.props {
+        api_key = {{ AIRBRAKE_API_KEY }}
+        env = {{ AIRBRAKE_ENVIRONMENT }}
+        enabled = {{ AIRBRAKE_ENABLED }}
+      }
       stdout.class = org.apache.log4j.ConsoleAppender
       stdout.props {
         layout.class = org.apache.log4j.PatternLayout

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -78,9 +78,10 @@ object Deps {
     "org.mock-server" % "mockserver-maven-plugin" % "3.10.1" % "test"
   )
 
+  // airbrake-java includes log4j
   lazy val logging = Seq(
-    "log4j" % "log4j" % "1.2.17",
-    "org.slf4j" % "slf4j-log4j12" % "1.7.10"
+    "org.slf4j" % "slf4j-log4j12" % "1.7.10",
+    "io.airbrake" % "airbrake-java" % "2.2.8" % "provided"
   )
 
   lazy val rojoma = Seq(


### PR DESCRIPTION
I can't get this to actually throw exceptions, so I haven't confirmed that it works yet.

In apps-marathon, I added....

`"AIRBRAKE_API_KEY": "abcd1234"`
to cetera.json

and 
```
LOG_PATHS = "[ INFO, stdout, airbrake ]"
AIRBRAKE_ENVIRONMENT = "aws_us_west2_prod"
AIRBRAKE_ENABLED = "true"
```
to cetera.toml. Don't include `airbrake` in the `LOG_PATHS` of staging or rc, change the environment accordingly, and set `AIRBRAKE_ENABLED` to `false` in those two envs.
