### PR TITLE
Refactor domain creation in tests to use a tsv file

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/types/Domain.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/Domain.scala
@@ -6,11 +6,11 @@ import org.slf4j.LoggerFactory
 import com.socrata.cetera.util.JsonDecodeException
 
 @JsonKeyStrategy(Strategy.Underscore)
-case class Domain(isCustomerDomain: Boolean,
-                  organization: Option[String],
+case class Domain(domainId: Int,
                   domainCname: String,
-                  domainId: Int,
                   siteTitle: Option[String],
+                  organization: Option[String],
+                  isCustomerDomain: Boolean,
                   moderationEnabled: Boolean,
                   routingApprovalEnabled: Boolean,
                   lockedDown: Boolean,

--- a/cetera-http/src/test/resources/domains.tsv
+++ b/cetera-http/src/test/resources/domains.tsv
@@ -1,0 +1,10 @@
+id	cname	siteTitle	Organization	isCustomerDomain	isDomainModerated	hasRoutingApproval	lockedDown	apiLockedDown
+0	petercetera.net	Temporary URI	org	true	false	false	false	false
+1	opendata-demo.socrata.com	And other things	org	false	true	false	false	false
+2	blue.org	Fame and Fortune	org	true	false	true	false	false
+3	annabelle.island.net	Socrata Demo	org	true	true	true	false	false
+4	dylan.demo.socrata.com	Skid Row	Hair Metal Bands	true	false	true	false	false
+5	dylan2.demo.socrata.com	Mötley Crüe	Hair Metal Bands	false	false	false	false	false
+6	locked.demo.com	Locked Down	org	false	true	true	true	false
+7	api.locked.demo.com	Api Locked Down	org	true	true	false	false	true
+8	double.locked.demo.com	Doubly Locked Down	org	true	true	true	true	true

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESDataSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESDataSpec.scala
@@ -49,7 +49,7 @@ class TestESDataSpec extends FunSuiteLike with Matchers with TestESData with Bef
   test("test docs are bootstrapped") {
     val res = client.client.prepareSearch().execute.actionGet
     val numDocs = Datatypes.materialized.length + 4
-    val numDomains = domainCnames.length + 2
+    val numDomains = domainsWithData.length + 5  // 2 dylan domains and 3 locked domains without data
     res.getHits.getTotalHits should be(numDocs + numDomains)
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -476,11 +476,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
     "build a faceted request" in {
       val domainId = 42
       val domain = Domain(
+        domainId, "", None, None,
         isCustomerDomain = true,
-        None,
-        "",
-        domainId,
-        None,
         moderationEnabled = false,
         routingApprovalEnabled = false,
         lockedDown = false,
@@ -838,7 +835,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
 
   "chooseMinShouldMatch" should {
     val msm = Some("2<-25% 9<-3") // I can be an involved string
-    val sc = Domain(false, None, "example.com", 1, Some("Example! (dotcom)"), false, false, false, false)
+    val sc = Domain(1, "example.com", Some("Example! (dotcom)"), None, false, false, false, false, false)
 
     "choose minShouldMatch if present" in {
       documentClient.chooseMinShouldMatch(msm, None) should be (msm)

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
@@ -24,11 +24,11 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData with
   "find" should {
     "return the domain if it exists : petercetera.net" in {
       val expectedDomain = Domain(
-        isCustomerDomain = true,
-        organization = Some(""),
-        domainCname = "petercetera.net",
         domainId = 0,
+        domainCname = "petercetera.net",
         siteTitle = Some("Temporary URI"),
+        organization = Some("org"),
+        isCustomerDomain = true,
         moderationEnabled = false,
         routingApprovalEnabled = false,
         lockedDown = false,
@@ -39,11 +39,11 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData with
 
     "return the domain if it exists : opendata-demo.socrata.com" in {
       val expectedDomain = Domain(
-        isCustomerDomain = false,
-        organization = Some(""),
-        domainCname = "opendata-demo.socrata.com",
         domainId = 1,
+        domainCname = "opendata-demo.socrata.com",
         siteTitle = Some("And other things"),
+        organization = Some("org"),
+        isCustomerDomain = false,
         moderationEnabled = true,
         routingApprovalEnabled = false,
         lockedDown = false,
@@ -66,13 +66,13 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData with
 
     "return only domains with an exact match" in {
       val expectedDomain = Domain(
-        isCustomerDomain = true,
-        organization = Some(""),
-        domainCname = "dylan.demo.socrata.com",
         domainId = 4,
-        siteTitle = Some("Temporary URI"),
+        domainCname = "dylan.demo.socrata.com",
+        siteTitle = Some("Skid Row"),
+        organization = Some("Hair Metal Bands"),
+        isCustomerDomain = true,
         moderationEnabled = false,
-        routingApprovalEnabled = false,
+        routingApprovalEnabled = true,
         lockedDown = false,
         apiLockedDown = false)
 

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
@@ -94,11 +94,11 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
       val expected = Sorts.sortScoreDesc
 
       val searchContext = Domain(
-        isCustomerDomain = false,
-        organization = Some("SDP"),
-        domainCname = "peterschneider.net",
         domainId = 1,
+        domainCname = "peterschneider.net",
         siteTitle = Some("Temporary URI"),
+        organization = Some("SDP"),
+        isCustomerDomain = false,
         moderationEnabled = false,
         routingApprovalEnabled = true,
         lockedDown = false,

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/DomainCountServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/DomainCountServiceSpec.scala
@@ -56,7 +56,9 @@ class DomainCountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAf
       Count("dylan.demo.socrata.com", 0),
       // opendata-demo.socrata.com is not a customer domain, so the domain and all docs should be hidden
       // Count("opendata-demo.socrata.com", 0),
-      Count("petercetera.net", 4))
+      Count("petercetera.net", 4),
+      Count("api.locked.demo.com", 0),
+      Count("double.locked.demo.com", 0))
     val (res, _) = service.doAggregate(Map.empty)
     res.results should contain theSameElementsAs expectedResults
   }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
@@ -27,7 +27,7 @@ class FacetServiceSpec extends FunSuiteLike with Matchers with TestESData with B
   }
 
   test("retrieve all visible domain facets") {
-    val (datatypes, categories, tags, facets) = domainCnames.map { cname =>
+    val (datatypes, categories, tags, facets) = domainsWithData.map { cname =>
       val (facets, timings) = service.doAggregate(cname)
       timings.searchMillis.headOption should be('defined)
 

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -95,11 +95,11 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
 
   test("extract and format resources from SearchResponse") {
     val domain = Domain(
-      isCustomerDomain = true,
-      Some("Temp Org"),
-      "tempuri.org",
       1,
+      "tempuri.org",
       Some("Title"),
+      Some("Temp Org"),
+      isCustomerDomain = true,
       moderationEnabled = false,
       routingApprovalEnabled = false,
       lockedDown = false,

--- a/cetera-perf/src/main/scala/com/socrata/cetera/PerfESClient.scala
+++ b/cetera-perf/src/main/scala/com/socrata/cetera/PerfESClient.scala
@@ -77,11 +77,11 @@ class PerfESClient(testSuiteName: String = "catalog")
       Random.shuffle(tlds).head
     ).mkString(".")
     Domain(
-      Random.nextBoolean(),
-      Some(Random.alphanumeric.take(8).force.mkString),
-      domainCname,
       domainId,
+      domainCname,
       Some(Random.alphanumeric.take(16).force.mkString),
+      Some(Random.alphanumeric.take(8).force.mkString),
+      Random.nextBoolean(),
       Random.nextBoolean(),
       Random.nextBoolean(),
       Random.nextBoolean(),


### PR DESCRIPTION
#### What it do?

1.  As we talked about, this replaces the domain creation in test with a method that reads the tsv file I've added.
2. I also rearranged the order of params in Domain.  It was just so illogical to me.  So I placed id and cname first since these are the essential identifiers and all the booleans grouped together at the end.

#### How U test?
Test changes tested via `sbt test`  and of course `sbt styleCheck`