### PR TITLE
Fix airbrake inclusion in assembly

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -81,7 +81,7 @@ object Deps {
   // airbrake-java includes log4j
   lazy val logging = Seq(
     "org.slf4j" % "slf4j-log4j12" % "1.7.10",
-    "io.airbrake" % "airbrake-java" % "2.2.8" % "provided"
+    "io.airbrake" % "airbrake-java" % "2.2.8" exclude("commons-logging", "commons-logging")
   )
 
   lazy val rojoma = Seq(


### PR DESCRIPTION
in the error logs for cetera-https find the following:

exec su socrata -c "$CMD"
log4j:ERROR Could not instantiate class [airbrake.AirbrakeAppender].
java.lang.ClassNotFoundException: airbrake.AirbrakeAppender
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at org.apache.log4j.helpers.Loader.loadClass(Loader.java:198)
	at org.apache.log4j.helpers.OptionConverter.instantiateByClassName(OptionConverter.java:327)
	at org.apache.log4j.helpers.OptionConverter.instantiateByKey(OptionConverter.java:124)
	at org.apache.log4j.PropertyConfigurator.parseAppender(PropertyConfigurator.java:785)
	at org.apache.log4j.PropertyConfigurator.parseCategory(PropertyConfigurator.java:768)
	at org.apache.log4j.PropertyConfigurator.configureRootCategory(PropertyConfigurator.java:648)
	at org.apache.log4j.PropertyConfigurator.doConfigure(PropertyConfigurator.java:514)
	at org.apache.log4j.PropertyConfigurator.configure(PropertyConfigurator.java:440)
	at com.socrata.cetera.SearchServer$.delayedEndpoint$com$socrata$cetera$SearchServer$1(SearchServer.scala:25)
	at com.socrata.cetera.SearchServer$delayedInit$body.apply(SearchServer.scala:23)
	at scala.Function0$class.apply$mcV$sp(Function0.scala:34)
	at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:12)
	at scala.App$$anonfun$main$1.apply(App.scala:76)
	at scala.App$$anonfun$main$1.apply(App.scala:76)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at scala.collection.generic.TraversableForwarder$class.foreach(TraversableForwarder.scala:35)
	at scala.App$class.main(App.scala:76)
	at com.socrata.cetera.SearchServer$.main(SearchServer.scala:23)
	at com.socrata.cetera.SearchServer.main(SearchServer.scala)
log4j:ERROR Could not instantiate appender named "airbrake".
