### PR TITLE
EN-5254 pass along requestId from frontend to core

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/package.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/package.scala
@@ -4,6 +4,9 @@ import com.socrata.http.server.responses._
 
 package object cetera {
   val HeaderAclAllowOriginAll = Header("Access-Control-Allow-Origin", "*")
+  val HeaderCookieKey = "Cookie"
+  val HeaderXSocrataHostKey = "X-Socrata-Host"
+  val HeaderXSocrataRequestIdKey = "X-Socrata-RequestId"
 
   val esDocumentType = "document"
   val esDomainType = "domain"

--- a/cetera-http/src/main/scala/com/socrata/cetera/package.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/package.scala
@@ -5,6 +5,7 @@ import com.socrata.http.server.responses._
 package object cetera {
   val HeaderAclAllowOriginAll = Header("Access-Control-Allow-Origin", "*")
   val HeaderCookieKey = "Cookie"
+  val HeaderSetCookieKey = "Set-Cookie"
   val HeaderXSocrataHostKey = "X-Socrata-Host"
   val HeaderXSocrataRequestIdKey = "X-Socrata-RequestId"
 

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentClient.scala
@@ -8,13 +8,45 @@ import com.socrata.cetera._
 import com.socrata.cetera.search.DocumentAggregations._
 import com.socrata.cetera.types._
 
+trait BaseDocumentClient {
+  def buildSearchRequest( // scalastyle:ignore parameter.number
+                          searchQuery: QueryType,
+                          domains: Set[Domain],
+                          domainMetadata: Option[Set[(String, String)]],
+                          searchContext: Option[Domain],
+                          categories: Option[Set[String]],
+                          tags: Option[Set[String]],
+                          only: Option[Seq[String]],
+                          fieldBoosts: Map[CeteraFieldType with Boostable, Float],
+                          datatypeBoosts: Map[Datatype, Float],
+                          domainIdBoosts: Map[Int, Float],
+                          minShouldMatch: Option[String],
+                          slop: Option[Int],
+                          offset: Int,
+                          limit: Int,
+                          sortOrder: Option[String])
+  : SearchRequestBuilder
+
+  def buildCountRequest(
+                         field: DocumentFieldType with Countable with Rawable,
+                         searchQuery: QueryType,
+                         domains: Set[Domain],
+                         searchContext: Option[Domain],
+                         categories: Option[Set[String]],
+                         tags: Option[Set[String]],
+                         only: Option[Seq[String]])
+  : SearchRequestBuilder
+
+  def buildFacetRequest(domain: Option[Domain]): SearchRequestBuilder
+}
+
 class DocumentClient(
     esClient: ElasticSearchClient,
-    domainClient: DomainClient,
+    domainClient: BaseDomainClient,
     indexAliasName: String,
     defaultTitleBoost: Option[Float],
     defaultMinShouldMatch: Option[String],
-    scriptScoreFunctions: Set[ScriptScoreFunction]) {
+    scriptScoreFunctions: Set[ScriptScoreFunction]) extends BaseDocumentClient {
 
   // This query is complex, as it generates two queries that are then combined
   // into a single query. By default, the must match clause enforces a term match

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -11,7 +11,23 @@ import com.socrata.cetera.search.DomainFilters.{domainIdsFilter, isCustomerDomai
 import com.socrata.cetera.types.{Domain, DomainCnameFieldType}
 import com.socrata.cetera.util.{JsonDecodeException, LogHelper}
 
-class DomainClient(esClient: ElasticSearchClient, coreClient: CoreClient, indexAliasName: String) {
+trait BaseDomainClient {
+  def fetch(id: Int): Option[Domain]
+
+  def findRelevantDomains(searchContextCname: Option[String],
+                          domainCnames: Option[Set[String]],
+                          cookie: Option[String],
+                          requestId: Option[String])
+  : (Option[Domain], Set[Domain], Long, Seq[String])
+
+  def calculateIdsAndModRAStatuses(domains: Set[Domain]): (Set[Int], Set[Int], Set[Int], Set[Int])
+
+  def buildCountRequest(domains: Set[Domain], searchContext: Option[Domain]): SearchRequestBuilder
+}
+
+class DomainClient(esClient: ElasticSearchClient, coreClient: CoreClient, indexAliasName: String)
+  extends BaseDomainClient {
+
   val logger = LoggerFactory.getLogger(getClass)
 
   def fetch(id: Int): Option[Domain] = {

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -13,12 +13,12 @@ import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.search.{DocumentClient, DomainClient, DomainNotFound}
+import com.socrata.cetera.search.{BaseDocumentClient, BaseDomainClient, DomainNotFound}
 import com.socrata.cetera.types._
 import com.socrata.cetera.util.JsonResponses.jsonError
 import com.socrata.cetera.util._
 
-class CountService(documentClient: DocumentClient, domainClient: DomainClient) {
+class CountService(documentClient: BaseDocumentClient, domainClient: BaseDomainClient) {
   lazy val logger = LoggerFactory.getLogger(classOf[CountService])
 
   // Possibly belongs in the client

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/DomainCountService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/DomainCountService.scala
@@ -13,12 +13,12 @@ import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.search.{DomainClient, DomainNotFound}
+import com.socrata.cetera.search.{BaseDomainClient, DomainNotFound}
 import com.socrata.cetera.types.Count
 import com.socrata.cetera.util.JsonResponses.jsonError
 import com.socrata.cetera.util._
 
-class DomainCountService(domainClient: DomainClient) {
+class DomainCountService(domainClient: BaseDomainClient) {
   lazy val logger = LoggerFactory.getLogger(classOf[CountService])
 
   private def extract(json: JValue): Either[DecodeError, Seq[JValue]] = {

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/FacetService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/FacetService.scala
@@ -13,12 +13,12 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.search.{DocumentClient, DomainClient, DomainNotFound}
+import com.socrata.cetera.search.{BaseDocumentClient, BaseDomainClient, DomainNotFound}
 import com.socrata.cetera.types._
 import com.socrata.cetera.util.JsonResponses._
 import com.socrata.cetera.util._
 
-class FacetService(documentClient: DocumentClient, domainClient: DomainClient) {
+class FacetService(documentClient: BaseDocumentClient, domainClient: BaseDomainClient) {
   lazy val logger = LoggerFactory.getLogger(classOf[FacetService])
 
   // $COVERAGE-OFF$ jetty wiring

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
 import com.socrata.cetera.metrics.BalboaClient
-import com.socrata.cetera.search.{DocumentClient, DomainClient, DomainNotFound}
+import com.socrata.cetera.search.{BaseDocumentClient, BaseDomainClient, DomainNotFound}
 import com.socrata.cetera.types._
 import com.socrata.cetera.util.JsonResponses._
 import com.socrata.cetera.util._
@@ -43,8 +43,8 @@ object SearchResult {
   implicit val jCodec = AutomaticJsonCodecBuilder[SearchResult]
 }
 
-class SearchService(elasticSearchClient: DocumentClient,
-                    domainClient: DomainClient,
+class SearchService(elasticSearchClient: BaseDocumentClient,
+                    domainClient: BaseDomainClient,
                     balboaClient: BalboaClient) extends SimpleResource {
   lazy val logger = LoggerFactory.getLogger(classOf[SearchService])
 
@@ -242,7 +242,6 @@ class SearchService(elasticSearchClient: DocumentClient,
     }
   }
 
-  // $COVERAGE-OFF$ jetty wiring
   def search(req: HttpRequest): HttpResponse = {
     logger.debug(LogHelper.formatHttpRequestVerbose(req))
 
@@ -270,6 +269,7 @@ class SearchService(elasticSearchClient: DocumentClient,
     }
   }
 
+  // $COVERAGE-OFF$ jetty wiring
   object Service extends SimpleResource {
     override def get: HttpService = search
   }

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/Http.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/Http.scala
@@ -1,5 +1,7 @@
 package com.socrata.cetera.util
 
+import javax.servlet.http.HttpServletResponse
+
 import com.socrata.http.server.HttpResponse
 import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
@@ -11,9 +13,29 @@ object Http {
   lazy val logger = LoggerFactory.getLogger(Http.getClass)
 
   def decorate(content: HttpResponse, status: StatusResponse, setCookies: Seq[String]): HttpResponse = {
-    val baseResponse = status ~> HeaderAclAllowOriginAll
-    val responseWithCookies = setCookies.foldLeft(baseResponse){ case (r, s) => r ~> Header(HeaderSetCookieKey, s) }
-    logger.debug(LogHelper.formatHttpResponseHeaders(setCookies))
+    val debugMessage = StringBuilder.newBuilder
+    debugMessage.append(s"sending http response with (partial) headers:\n")
+
+    val baseResponse: HttpResponse = status ~> HeaderAclAllowOriginAll
+    debugMessage.append(s"HTTP ${status.statusCode}\n")
+    debugMessage.append("Access-Control-Allow-Origin: *\n")
+
+    // It would really be nice if socrata-http assembled a chained http request with multiple cookies.
+    //
+    // Someday we might want to secure cookies coming out of catalog api, like frontend does now,
+    // but only if we enable and require HTTPS connections.
+    // See https://en.wikipedia.org/wiki/HTTP_cookie#Cross-site_scripting_.E2.80.93_cookie_theft
+    //
+    // Additionally, frontend code limits the cookies in forwardable_session_cookies; another time perhaps.
+    val responseWithCookies = setCookies.foldLeft(baseResponse){ case (r, s) =>
+      debugMessage.append(s"$HeaderSetCookieKey: $s\n")
+      r.compose[HttpServletResponse] { sr =>
+        sr.addHeader(HeaderSetCookieKey, s)
+        sr
+      }
+    }
+
+    logger.debug(debugMessage.toString())
     responseWithCookies ~> content
   }
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/Http.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/Http.scala
@@ -1,0 +1,19 @@
+package com.socrata.cetera.util
+
+import com.socrata.http.server.HttpResponse
+import com.socrata.http.server.implicits._
+import com.socrata.http.server.responses._
+import org.slf4j.LoggerFactory
+
+import com.socrata.cetera._
+
+object Http {
+  lazy val logger = LoggerFactory.getLogger(Http.getClass)
+
+  def decorate(content: HttpResponse, status: StatusResponse, setCookies: Seq[String]): HttpResponse = {
+    val baseResponse = status ~> HeaderAclAllowOriginAll
+    val responseWithCookies = setCookies.foldLeft(baseResponse){ case (r, s) => r ~> Header(HeaderSetCookieKey, s) }
+    logger.debug(LogHelper.formatHttpResponseHeaders(setCookies))
+    responseWithCookies ~> content
+  }
+}

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/LogHelper.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/LogHelper.scala
@@ -51,13 +51,4 @@ object LogHelper {
 
     sb.toString()
   }
-
-  def formatHttpResponseHeaders(headers: Seq[String]): String = {
-    val sb = StringBuilder.newBuilder
-
-    sb.append(s"sending http response with headers:\n")
-    sb.append(s"${headers.mkString("\n")}\n")
-
-    sb.toString()
-  }
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/LogHelper.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/LogHelper.scala
@@ -51,4 +51,13 @@ object LogHelper {
 
     sb.toString()
   }
+
+  def formatHttpResponseHeaders(headers: Seq[String]): String = {
+    val sb = StringBuilder.newBuilder
+
+    sb.append(s"sending http response with headers:\n")
+    sb.append(s"${headers.mkString("\n")}\n")
+
+    sb.toString()
+  }
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/LogHelper.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/LogHelper.scala
@@ -1,7 +1,12 @@
 package com.socrata.cetera.util
 
+import scala.io.Source
+
+import com.socrata.http.client.RequestBuilder
 import com.socrata.http.server.HttpRequest
 import org.elasticsearch.action.search.SearchRequestBuilder
+
+import com.socrata.cetera._
 
 object LogHelper {
   // WARN: changing this will likely break Sumo (regex-based log parser)
@@ -12,6 +17,8 @@ object LogHelper {
       request.queryStr.getOrElse(""),
       "requested by",
       request.servletRequest.getRemoteHost,
+      s"extended host = ${request.header(HeaderXSocrataHostKey)}",
+      s"request id = ${request.header(HeaderXSocrataRequestIdKey)}",
       s"""TIMINGS ## ESTime : ${timings.searchMillis} ## ServiceTime : ${timings.serviceMillis}"""
     ).mkString(" -- ")
   }
@@ -19,5 +26,29 @@ object LogHelper {
   def formatEsRequest(search: SearchRequestBuilder): String = {
     s"""Elasticsearch request body: ${search.toString.replaceAll("""[\n\s]+""", " ")}
      """.stripMargin.trim
+  }
+
+  def formatHttpRequestVerbose(req: HttpRequest): String = {
+    val sb = StringBuilder.newBuilder
+
+    sb.append(s"received http request:\n")
+    sb.append(s"${req.method} ${req.requestPath.mkString("/","/","")}${req.queryStr.map("?" + _).getOrElse("")}\n")
+    req.headerNames.foreach { n =>
+      sb.append(s"$n: ${req.headers(n).mkString(", ")}\n")
+    }
+    sb.append("\n")
+    Source.fromInputStream(req.inputStream).getLines().foreach(line => sb.append(s"$line\n"))
+
+    sb.toString()
+  }
+
+  def formatSimpleHttpRequestBuilderVerbose(req: RequestBuilder): String = {
+    val sb = StringBuilder.newBuilder
+
+    sb.append(s"sending http request:\n")
+    sb.append(s"${req.method.getOrElse("GET")} ${req.path.mkString("/", "/", "")}\n")
+    sb.append(req.headers.map { case (k,v) => s"$k: $v" }.mkString("\n"))
+
+    sb.toString()
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/authentication/CoreClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/authentication/CoreClientSpec.scala
@@ -7,7 +7,7 @@ import org.mockserver.model.HttpRequest.request
 import org.mockserver.model.HttpResponse.response
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, ShouldMatchers, WordSpec}
 
-import com.socrata.cetera.{TestHttpClient, TestCoreClient}
+import com.socrata.cetera._
 
 class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll with BeforeAndAfterEach {
 
@@ -44,7 +44,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
       request()
         .withMethod("GET")
         .withPath("/users.json")
-        .withHeader("X-Socrata-Host", domain)
+        .withHeader(HeaderXSocrataHostKey, domain)
     ).respond(
       response()
         .withStatusCode(200)
@@ -60,7 +60,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
       request()
         .withMethod("GET")
         .withPath("/users.json")
-        .withHeader("X-Socrata-Host", domain)
+        .withHeader(HeaderXSocrataHostKey, domain)
     ).respond(
       response()
         .withStatusCode(200)
@@ -72,8 +72,8 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
   "The optionallyGetUserByCookie method" should {
     "return None if no cookie is given" in {
       setUpMockWithAuthorizedUser()
-      val userWithoutContext = coreClient.optionallyGetUserByCookie(None, None)
-      val userWithContext = coreClient.optionallyGetUserByCookie(Some(domain), None)
+      val userWithoutContext = coreClient.optionallyGetUserByCookie(None, None, None)
+      val userWithContext = coreClient.optionallyGetUserByCookie(Some(domain), None, None)
 
       userWithoutContext should be(None)
       userWithContext should be(None)
@@ -81,16 +81,16 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
 
     "return None if no context is given" in {
       setUpMockWithAuthorizedUser()
-      val userWithoutCookie = coreClient.optionallyGetUserByCookie(None, None)
-      val userWithCookie = coreClient.optionallyGetUserByCookie(None, Some(cookie))
+      val userWithoutCookie = coreClient.optionallyGetUserByCookie(None, None, None)
+      val userWithCookie = coreClient.optionallyGetUserByCookie(None, Some(cookie), None)
 
       userWithoutCookie should be(None)
       userWithCookie should be(None)
     }
 
-    "return Some user if both the context and cookie are given" in {
+    "return Some user if both the valid context and correct cookie are given" in {
       setUpMockWithAuthorizedUser()
-      val user = coreClient.optionallyGetUserByCookie(Some(domain), Some(cookie))
+      val user = coreClient.optionallyGetUserByCookie(Some(domain), Some(cookie), None)
 
       user should be('defined)
       user.get should have('id ("boo-bear"))
@@ -101,6 +101,29 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
     // WARNING: Socrata-http requires that cookies have the form key=value, otherwise it will respond with
     // 'The target server failed to respond'
 
+    "pass along requestid in core request" in {
+      val userBody = j"""["bar"]"""
+      val reqId = "42"
+      val expectedRequest =
+        request()
+          .withMethod("GET")
+          .withPath(s"/users.json")
+          .withHeader(HeaderXSocrataHostKey, domain)
+          .withHeader(HeaderXSocrataRequestIdKey, reqId)
+
+      mockServer.when(
+        expectedRequest
+      ).respond(
+        response()
+          .withStatusCode(200)
+          .withHeader("Content-Type", "application/json; charset=utf-8")
+          .withBody(CompactJsonWriter.toString(userBody))
+      )
+
+      coreClient.fetchUserByCookie(domain, cookie, Some(reqId))
+      mockServer.verify(expectedRequest)
+    }
+
     "return the user if core returns a 200 and an empowered user" in {
       setUpMockWithAuthorizedUser()
       val expectedUser = User(
@@ -109,7 +132,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
         Some(List("steal_honey", "scare_tourists")),
         Some(List("admin")))
 
-      val actualUser = coreClient.fetchUserByCookie(domain, cookie)
+      val actualUser = coreClient.fetchUserByCookie(domain, cookie, None)
       actualUser.get should be(expectedUser)
     }
 
@@ -117,14 +140,14 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
       setUpMockWithUnauthorizeddUser()
       val expectedUser = User("lazy-bear", None, None, None)
 
-      val actualUser = coreClient.fetchUserByCookie(domain, cookie)
+      val actualUser = coreClient.fetchUserByCookie(domain, cookie, None)
       actualUser.get should be(expectedUser)
     }
 
 
     "return None without calling core if passed an empty cookie" in {
       setUpMockWithAuthorizedUser()
-      coreClient.fetchUserByCookie(domain, "") should be(None)
+      coreClient.fetchUserByCookie(domain, "", None) should be(None)
     }
 
     "return None if core returns a 401" in {
@@ -139,7 +162,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
             .withStatusCode(401)
         )
 
-      coreClient.fetchUserByCookie(domain, cookie) should be(None)
+      coreClient.fetchUserByCookie(domain, cookie, None) should be(None)
     }
 
     "return None if core returns a 403" in {
@@ -154,7 +177,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
             .withStatusCode(403)
         )
 
-      coreClient.fetchUserByCookie(domain, cookie) should be(None)
+      coreClient.fetchUserByCookie(domain, cookie, None) should be(None)
     }
 
     "return None if core returns a 500" in {
@@ -169,11 +192,35 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
             .withStatusCode(500)
         )
 
-      coreClient.fetchUserByCookie(domain, cookie) should be(None)
+      coreClient.fetchUserByCookie(domain, cookie, None) should be(None)
     }
   }
 
   "The fetchUserById method" should {
+    "pass along requestid in core request" in {
+      val fxf = "foo-bear"
+      val userBody = j"""["bar"]"""
+      val reqId = "42"
+      val expectedRequest =
+        request()
+          .withMethod("GET")
+          .withPath(s"/users/$fxf")
+          .withHeader(HeaderXSocrataHostKey, domain)
+          .withHeader(HeaderXSocrataRequestIdKey, reqId)
+
+      mockServer.when(
+        expectedRequest
+      ).respond(
+        response()
+          .withStatusCode(200)
+          .withHeader("Content-Type", "application/json; charset=utf-8")
+          .withBody(CompactJsonWriter.toString(userBody))
+      )
+
+      coreClient.fetchUserById(domain, fxf, Some(reqId))
+      mockServer.verify(expectedRequest)
+    }
+
     "return the user if core returns a 200" in {
       val fxf = "boo-bear"
       val userBody =
@@ -191,7 +238,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
         request()
           .withMethod("GET")
           .withPath(s"/users/$fxf")
-          .withHeader("X-Socrata-Host", domain)
+          .withHeader(HeaderXSocrataHostKey, domain)
       ).respond(
         response()
           .withStatusCode(200)
@@ -206,7 +253,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
         Some(List("admin"))
       )
 
-      val actualUser = coreClient.fetchUserById(domain, fxf)
+      val actualUser = coreClient.fetchUserById(domain, fxf, None)
       actualUser.get should be(expectedUser)
     }
 
@@ -222,14 +269,14 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
         request()
           .withMethod("GET")
           .withPath(s"/users/$fxf")
-          .withHeader("X-Socrata-Host", domain)
+          .withHeader(HeaderXSocrataHostKey, domain)
       ).respond(
         response()
           .withStatusCode(200)
           .withHeader("Content-Type", "application/json; charset=utf-8")
           .withBody(CompactJsonWriter.toString(userBody))
       )
-      coreClient.fetchUserById(domain, fxf) should be(None)
+      coreClient.fetchUserById(domain, fxf, None) should be(None)
     }
 
     "return None if core returns a 405" in {
@@ -245,7 +292,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
             .withStatusCode(405)
         )
 
-      coreClient.fetchUserById(domain, fxf) should be(None)
+      coreClient.fetchUserById(domain, fxf, None) should be(None)
     }
   }
 }
@@ -261,13 +308,13 @@ class CoreClientlessSpec extends WordSpec with ShouldMatchers {
 
   "When core is not reachable, the fetchUserByCookie method" should {
     "return None" in {
-      coreClient.fetchUserByCookie(domain, cookie) should be(None)
+      coreClient.fetchUserByCookie(domain, cookie, None) should be(None)
     }
   }
 
   "When core is not reachable, the fetchUserById method" should {
     "return None" in {
-      coreClient.fetchUserById(domain, "four-four") should be(None)
+      coreClient.fetchUserById(domain, "four-four", None) should be(None)
     }
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/authentication/CoreClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/authentication/CoreClientSpec.scala
@@ -75,8 +75,8 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
       val userWithoutContext = coreClient.optionallyGetUserByCookie(None, None, None)
       val userWithContext = coreClient.optionallyGetUserByCookie(Some(domain), None, None)
 
-      userWithoutContext should be(None)
-      userWithContext should be(None)
+      userWithoutContext._1 should be(None)
+      userWithContext._1 should be(None)
     }
 
     "return None if no context is given" in {
@@ -84,13 +84,13 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
       val userWithoutCookie = coreClient.optionallyGetUserByCookie(None, None, None)
       val userWithCookie = coreClient.optionallyGetUserByCookie(None, Some(cookie), None)
 
-      userWithoutCookie should be(None)
-      userWithCookie should be(None)
+      userWithoutCookie._1 should be(None)
+      userWithCookie._1 should be(None)
     }
 
     "return Some user if both the valid context and correct cookie are given" in {
       setUpMockWithAuthorizedUser()
-      val user = coreClient.optionallyGetUserByCookie(Some(domain), Some(cookie), None)
+      val (user, _) = coreClient.optionallyGetUserByCookie(Some(domain), Some(cookie), None)
 
       user should be('defined)
       user.get should have('id ("boo-bear"))
@@ -124,6 +124,27 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
       mockServer.verify(expectedRequest)
     }
 
+    "pass back set-cookie from the core response" in {
+      val userBody = j"""["bar"]"""
+      val expectedSetCookie = "everything=awesome"
+
+      mockServer.when(
+        request()
+          .withMethod("GET")
+          .withPath(s"/users.json")
+          .withHeader(HeaderXSocrataHostKey, domain)
+      ).respond(
+        response()
+          .withStatusCode(200)
+          .withHeader("Content-Type", "application/json; charset=utf-8")
+          .withHeader(HeaderSetCookieKey, expectedSetCookie)
+          .withBody(CompactJsonWriter.toString(userBody))
+      )
+
+      val (_, setCookies) = coreClient.fetchUserByCookie(domain, cookie, None)
+      setCookies should contain theSameElementsAs Seq(expectedSetCookie)
+    }
+
     "return the user if core returns a 200 and an empowered user" in {
       setUpMockWithAuthorizedUser()
       val expectedUser = User(
@@ -132,7 +153,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
         Some(List("steal_honey", "scare_tourists")),
         Some(List("admin")))
 
-      val actualUser = coreClient.fetchUserByCookie(domain, cookie, None)
+      val (actualUser, _) = coreClient.fetchUserByCookie(domain, cookie, None)
       actualUser.get should be(expectedUser)
     }
 
@@ -140,14 +161,14 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
       setUpMockWithUnauthorizeddUser()
       val expectedUser = User("lazy-bear", None, None, None)
 
-      val actualUser = coreClient.fetchUserByCookie(domain, cookie, None)
+      val (actualUser, _) = coreClient.fetchUserByCookie(domain, cookie, None)
       actualUser.get should be(expectedUser)
     }
 
 
     "return None without calling core if passed an empty cookie" in {
       setUpMockWithAuthorizedUser()
-      coreClient.fetchUserByCookie(domain, "", None) should be(None)
+      coreClient.fetchUserByCookie(domain, "", None)._1 should be(None)
     }
 
     "return None if core returns a 401" in {
@@ -162,7 +183,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
             .withStatusCode(401)
         )
 
-      coreClient.fetchUserByCookie(domain, cookie, None) should be(None)
+      coreClient.fetchUserByCookie(domain, cookie, None)._1 should be(None)
     }
 
     "return None if core returns a 403" in {
@@ -177,7 +198,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
             .withStatusCode(403)
         )
 
-      coreClient.fetchUserByCookie(domain, cookie, None) should be(None)
+      coreClient.fetchUserByCookie(domain, cookie, None)._1 should be(None)
     }
 
     "return None if core returns a 500" in {
@@ -192,7 +213,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
             .withStatusCode(500)
         )
 
-      coreClient.fetchUserByCookie(domain, cookie, None) should be(None)
+      coreClient.fetchUserByCookie(domain, cookie, None)._1 should be(None)
     }
   }
 
@@ -219,6 +240,28 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
 
       coreClient.fetchUserById(domain, fxf, Some(reqId))
       mockServer.verify(expectedRequest)
+    }
+
+    "pass back set-cookie from the core response" in {
+      val fxf = "foo-bear"
+      val userBody = j"""["bar"]"""
+      val expectedSetCookie = "everything=awesome"
+
+      mockServer.when(
+        request()
+          .withMethod("GET")
+          .withPath(s"/users/$fxf")
+          .withHeader(HeaderXSocrataHostKey, domain)
+      ).respond(
+        response()
+          .withStatusCode(200)
+          .withHeader("Content-Type", "application/json; charset=utf-8")
+          .withHeader(HeaderSetCookieKey, expectedSetCookie)
+          .withBody(CompactJsonWriter.toString(userBody))
+      )
+
+      val (_, setCookies) = coreClient.fetchUserById(domain, fxf, None)
+      setCookies should contain theSameElementsAs Seq(expectedSetCookie)
     }
 
     "return the user if core returns a 200" in {
@@ -253,7 +296,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
         Some(List("admin"))
       )
 
-      val actualUser = coreClient.fetchUserById(domain, fxf, None)
+      val (actualUser, _) = coreClient.fetchUserById(domain, fxf, None)
       actualUser.get should be(expectedUser)
     }
 
@@ -276,7 +319,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
           .withHeader("Content-Type", "application/json; charset=utf-8")
           .withBody(CompactJsonWriter.toString(userBody))
       )
-      coreClient.fetchUserById(domain, fxf, None) should be(None)
+      coreClient.fetchUserById(domain, fxf, None)._1 should be(None)
     }
 
     "return None if core returns a 405" in {
@@ -292,7 +335,7 @@ class CoreClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll
             .withStatusCode(405)
         )
 
-      coreClient.fetchUserById(domain, fxf, None) should be(None)
+      coreClient.fetchUserById(domain, fxf, None)._1 should be(None)
     }
   }
 }
@@ -308,13 +351,13 @@ class CoreClientlessSpec extends WordSpec with ShouldMatchers {
 
   "When core is not reachable, the fetchUserByCookie method" should {
     "return None" in {
-      coreClient.fetchUserByCookie(domain, cookie, None) should be(None)
+      coreClient.fetchUserByCookie(domain, cookie, None)._1 should be(None)
     }
   }
 
   "When core is not reachable, the fetchUserById method" should {
     "return None" in {
-      coreClient.fetchUserById(domain, "four-four", None) should be(None)
+      coreClient.fetchUserById(domain, "four-four", None)._1 should be(None)
     }
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
@@ -80,27 +80,27 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
   "findRelevantDomains" should {
     "return the context if it exists among customer domains: petercetera.net" in {
       val expectedContext = domains(0)
-      val (actualContext, _, _) = domainClient.findRelevantDomains(Some("petercetera.net"), None, None, None)
+      val (actualContext, _, _, _) = domainClient.findRelevantDomains(Some("petercetera.net"), None, None, None)
       actualContext.get should be(expectedContext)
     }
 
     "return the domain if it exists among the given cnames : opendata-demo.socrata.com" in {
       val expectedContext = domains(1)
-      val (actualContext, _, _) = domainClient.findRelevantDomains(
+      val (actualContext, _, _, _) = domainClient.findRelevantDomains(
         Some("opendata-demo.socrata.com"), Some(Set("opendata-demo.socrata.com")), None, None)
       actualContext.get should be(expectedContext)
     }
 
     "return all the unlocked customer domains if not given cnames" in {
       val unlockedDomains = Set(domains(0), domains(2), domains(3), domains(4))
-      val (_, actualDomains, _) = domainClient.findRelevantDomains(None, None, None, None)
+      val (_, actualDomains, _, _) = domainClient.findRelevantDomains(None, None, None, None)
       actualDomains should be(unlockedDomains)
     }
 
     "return all the unlocked domains among the given cnames if they exist" in {
       val expectedDomains = Set(domains(3), domains(4))
       val wantedDomains = Some(expectedDomains.map(d => d.domainCname))
-      val (_, actualDomains, _) = domainClient.findRelevantDomains(None, wantedDomains, None, None)
+      val (_, actualDomains, _, _) = domainClient.findRelevantDomains(None, wantedDomains, None, None)
       actualDomains should be(expectedDomains)
     }
 
@@ -137,7 +137,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
           .withBody(CompactJsonWriter.toString(userBody))
       )
 
-      val (actualContext, actualDomains, _) = domainClient.findRelevantDomains(Some(context.domainCname),
+      val (actualContext, actualDomains, _, _) = domainClient.findRelevantDomains(Some(context.domainCname),
         Some(wantedCnames), Some("c=cookie"), None)
       actualContext.get should be(context)
       actualDomains should be(wantedDomains)
@@ -172,11 +172,11 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
     "return None for a locked context if the user has no cookie" in {
       val withoutDomains = domainClient.removeLockedDomainsForbiddenToUser(
         Some(lockedDomain), Set.empty[Domain], None, None)
-      withoutDomains should be((None, Set.empty[Domain]))
+      withoutDomains should be((None, Set.empty[Domain], Seq.empty))
 
       val withDomains = domainClient.removeLockedDomainsForbiddenToUser(
         Some(lockedDomain), Set(domains(1)), None, None)
-      withDomains should be((None, Set(domains(1))))
+      withDomains should be((None, Set(domains(1)), Seq.empty))
     }
 
     "return None for a locked context if the user has a bad cookie" in {
@@ -193,11 +193,11 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
 
       val withoutDomains = domainClient.removeLockedDomainsForbiddenToUser(
         Some(apiLockedDomain), Set.empty[Domain], Some("c=cookie"), None)
-      withoutDomains should be((None, Set.empty[Domain]))
+      withoutDomains should be((None, Set.empty[Domain], Seq.empty))
 
       val withDomains = domainClient.removeLockedDomainsForbiddenToUser(
         Some(apiLockedDomain), Set(domains(1)), Some("c=cookie"), None)
-      withDomains should be((None, Set(domains(1))))
+      withDomains should be((None, Set(domains(1)), Seq.empty))
     }
 
     "return None for a locked context if the user has no role" in {
@@ -223,11 +223,11 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
 
       val withoutDomains = domainClient.removeLockedDomainsForbiddenToUser(
         Some(doublyLockedDomain), Set.empty[Domain], Some("c=cookie"), None)
-      withoutDomains should be((None, Set.empty[Domain]))
+      withoutDomains should be((None, Set.empty[Domain], Seq.empty))
 
       val withDomains = domainClient.removeLockedDomainsForbiddenToUser(
         Some(doublyLockedDomain), Set(domains(1)), Some("c=cookie"), None)
-      withDomains should be((None, Set(domains(1))))
+      withDomains should be((None, Set(domains(1)), Seq.empty))
     }
 
     "return the locked down context if the user is logged in and has a role" in {
@@ -264,17 +264,17 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
 
       val res = domainClient.removeLockedDomainsForbiddenToUser(
         Some(lockedDomain), Set(lockedDomain), Some("c=cookie"), None)
-      res should be((Some(lockedDomain), Set(lockedDomain)))
+      res should be((Some(lockedDomain), Set(lockedDomain), Seq.empty))
     }
 
     "remove locked domains if the user has no cookie" in {
       val relevantDomains = Set(unlockedDomain0, lockedDomain)
       val withoutContext = domainClient.removeLockedDomainsForbiddenToUser(None, relevantDomains, None, None)
-      withoutContext should be((None, Set(unlockedDomain0)))
+      withoutContext should be((None, Set(unlockedDomain0), Seq.empty))
 
       val withContext = domainClient.removeLockedDomainsForbiddenToUser(
         Some(unlockedDomain0), relevantDomains, None, None)
-      withContext should be((Some(unlockedDomain0), Set(unlockedDomain0)))
+      withContext should be((Some(unlockedDomain0), Set(unlockedDomain0), Seq.empty))
     }
 
     "remove locked domains if the user has a bad cookie" in {
@@ -291,7 +291,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
       )
 
       val res = domainClient.removeLockedDomainsForbiddenToUser(Some(unlockedDomain0), relevantDomains, None, None)
-      res should be((Some(unlockedDomain0), Set(unlockedDomain0)))
+      res should be((Some(unlockedDomain0), Set(unlockedDomain0), Seq.empty))
     }
 
     "remove locked domains if the user has a good cookie, but no role on the locked domain (where domain is the context)" in {
@@ -328,7 +328,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
       )
 
       val res = domainClient.removeLockedDomainsForbiddenToUser(Some(apiLockedDomain), relevantDomains, None, None)
-      res should be((None, Set(unlockedDomain2)))
+      res should be((None, Set(unlockedDomain2), Seq.empty))
     }
 
     "remove locked domains if the user has a good cookie, but no role on the locked domain (where domain is not the context)" in {
@@ -383,28 +383,28 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
 
       val res = domainClient.removeLockedDomainsForbiddenToUser(
         Some(lockedDomain), relevantDomains, Some("c=cookie"), None)
-      res should be((Some(lockedDomain), Set(lockedDomain, unlockedDomain1)))
+      res should be((Some(lockedDomain), Set(lockedDomain, unlockedDomain1), Seq.empty))
     }
 
     "return all the things if nothing is locked down" in {
       val noContextNoDomains = domainClient.removeLockedDomainsForbiddenToUser(None, Set.empty[Domain], None, None)
-      noContextNoDomains should be((None, Set.empty[Domain]))
+      noContextNoDomains should be((None, Set.empty[Domain], Seq.empty))
 
       val noDomains = domainClient.removeLockedDomainsForbiddenToUser(
         Some(unlockedDomain0), Set.empty[Domain], None, None)
-      noDomains should be((Some(unlockedDomain0), Set.empty[Domain]))
+      noDomains should be((Some(unlockedDomain0), Set.empty[Domain], Seq.empty))
 
       val noContext = domainClient.removeLockedDomainsForbiddenToUser(None, Set(unlockedDomain1), None, None)
-      noContext should be((None, Set(unlockedDomain1)))
+      noContext should be((None, Set(unlockedDomain1), Seq.empty))
 
       val bothUnsharedContext = domainClient.removeLockedDomainsForbiddenToUser(
         Some(unlockedDomain0), Set(unlockedDomain2), None, None)
-      bothUnsharedContext should be((Some(unlockedDomain0), Set(unlockedDomain2)))
+      bothUnsharedContext should be((Some(unlockedDomain0), Set(unlockedDomain2), Seq.empty))
 
       val bothSharedContext = domainClient.removeLockedDomainsForbiddenToUser(
         Some(unlockedDomain1),
         Set(unlockedDomain1, unlockedDomain2), None, None)
-      bothSharedContext should be((Some(unlockedDomain1), Set(unlockedDomain1, unlockedDomain2)))
+      bothSharedContext should be((Some(unlockedDomain1), Set(unlockedDomain1, unlockedDomain2), Seq.empty))
 
     }
 
@@ -455,7 +455,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
 
       val res = domainClient.removeLockedDomainsForbiddenToUser(
         Some(apiLockedDomain), relevantDomains, Some("c=cookie"), None)
-      res should be((Some(apiLockedDomain), relevantDomains))
+      res should be((Some(apiLockedDomain), relevantDomains, Seq.empty))
     }
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DomainClientSpec.scala
@@ -8,8 +8,8 @@ import org.mockserver.model.HttpRequest.request
 import org.mockserver.model.HttpResponse.response
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, ShouldMatchers, WordSpec}
 
+import com.socrata.cetera._
 import com.socrata.cetera.types.Domain
-import com.socrata.cetera.{TestHttpClient, TestCoreClient, TestESClient, TestESData}
 
 // Please see https://github.com/socrata/cetera/blob/master/cetera-http/src/test/resources/domains.tsv
 // if you have any questions about which domains are being used in these tests
@@ -80,27 +80,27 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
   "findRelevantDomains" should {
     "return the context if it exists among customer domains: petercetera.net" in {
       val expectedContext = domains(0)
-      val (actualContext, _, _) = domainClient.findRelevantDomains(Some("petercetera.net"), None, None)
+      val (actualContext, _, _) = domainClient.findRelevantDomains(Some("petercetera.net"), None, None, None)
       actualContext.get should be(expectedContext)
     }
 
     "return the domain if it exists among the given cnames : opendata-demo.socrata.com" in {
       val expectedContext = domains(1)
       val (actualContext, _, _) = domainClient.findRelevantDomains(
-        Some("opendata-demo.socrata.com"), Some(Set("opendata-demo.socrata.com")), None)
+        Some("opendata-demo.socrata.com"), Some(Set("opendata-demo.socrata.com")), None, None)
       actualContext.get should be(expectedContext)
     }
 
     "return all the unlocked customer domains if not given cnames" in {
       val unlockedDomains = Set(domains(0), domains(2), domains(3), domains(4))
-      val (_, actualDomains, _) = domainClient.findRelevantDomains(None, None, None)
+      val (_, actualDomains, _) = domainClient.findRelevantDomains(None, None, None, None)
       actualDomains should be(unlockedDomains)
     }
 
     "return all the unlocked domains among the given cnames if they exist" in {
       val expectedDomains = Set(domains(3), domains(4))
       val wantedDomains = Some(expectedDomains.map(d => d.domainCname))
-      val (_, actualDomains, _) = domainClient.findRelevantDomains(None, wantedDomains, None)
+      val (_, actualDomains, _) = domainClient.findRelevantDomains(None, wantedDomains, None, None)
       actualDomains should be(expectedDomains)
     }
 
@@ -119,7 +119,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users.json")
-          .withHeader("X-Socrata-Host", context.domainCname)
+          .withHeader(HeaderXSocrataHostKey, context.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -138,32 +138,32 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
       )
 
       val (actualContext, actualDomains, _) = domainClient.findRelevantDomains(Some(context.domainCname),
-        Some(wantedCnames), Some("c=cookie"))
+        Some(wantedCnames), Some("c=cookie"), None)
       actualContext.get should be(context)
       actualDomains should be(wantedDomains)
     }
 
     "throw DomainNotFound exception when searchContext is missing" in {
       intercept[DomainNotFound] {
-        domainClient.findRelevantDomains(Some("iamnotarealdomain.wat"), None, None)
+        domainClient.findRelevantDomains(Some("iamnotarealdomain.wat"), None, None, None)
       }
     }
 
     "throw DomainNotFound exception when searchContext is missing even if domains are found" in {
       intercept[DomainNotFound] {
-        domainClient.findRelevantDomains(Some("iamnotarealdomain.wat"), Some(Set("dylan.demo.socrata.com")), None)
+        domainClient.findRelevantDomains(Some("iamnotarealdomain.wat"), Some(Set("dylan.demo.socrata.com")), None, None)
       }
     }
 
     "not throw DomainNotFound exception when searchContext is present" in {
       noException should be thrownBy {
-        domainClient.findRelevantDomains(Some("dylan.demo.socrata.com"), None, None)
+        domainClient.findRelevantDomains(Some("dylan.demo.socrata.com"), None, None, None)
       }
     }
 
     "not throw DomainNotFound exception when domains are missing" in {
       noException should be thrownBy {
-        domainClient.findRelevantDomains(None, Some(Set("iamnotarealdomain.wat")), None)
+        domainClient.findRelevantDomains(None, Some(Set("iamnotarealdomain.wat")), None, None)
       }
     }
   }
@@ -171,11 +171,11 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
   "removeLockedDomainsFromUnauthorizedUsers" should {
     "return None for a locked context if the user has no cookie" in {
       val withoutDomains = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(lockedDomain), Set.empty[Domain], None)
+        Some(lockedDomain), Set.empty[Domain], None, None)
       withoutDomains should be((None, Set.empty[Domain]))
 
       val withDomains = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(lockedDomain), Set(domains(1)), None)
+        Some(lockedDomain), Set(domains(1)), None, None)
       withDomains should be((None, Set(domains(1))))
     }
 
@@ -184,7 +184,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users.json")
-          .withHeader("X-Socrata-Host", apiLockedDomain.domainCname),
+          .withHeader(HeaderXSocrataHostKey, apiLockedDomain.domainCname),
         Times.exactly(2)
       ).respond(
         response()
@@ -192,11 +192,11 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
       )
 
       val withoutDomains = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(apiLockedDomain), Set.empty[Domain], Some("c=cookie"))
+        Some(apiLockedDomain), Set.empty[Domain], Some("c=cookie"), None)
       withoutDomains should be((None, Set.empty[Domain]))
 
       val withDomains = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(apiLockedDomain), Set(domains(1)), Some("c=cookie"))
+        Some(apiLockedDomain), Set(domains(1)), Some("c=cookie"), None)
       withDomains should be((None, Set(domains(1))))
     }
 
@@ -212,7 +212,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users.json")
-          .withHeader("X-Socrata-Host", doublyLockedDomain.domainCname),
+          .withHeader(HeaderXSocrataHostKey, doublyLockedDomain.domainCname),
         Times.exactly(2)
       ).respond(
         response()
@@ -222,11 +222,11 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
       )
 
       val withoutDomains = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(doublyLockedDomain), Set.empty[Domain], Some("c=cookie"))
+        Some(doublyLockedDomain), Set.empty[Domain], Some("c=cookie"), None)
       withoutDomains should be((None, Set.empty[Domain]))
 
       val withDomains = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(doublyLockedDomain), Set(domains(1)), Some("c=cookie"))
+        Some(doublyLockedDomain), Set(domains(1)), Some("c=cookie"), None)
       withDomains should be((None, Set(domains(1))))
     }
 
@@ -243,7 +243,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users.json")
-          .withHeader("X-Socrata-Host", lockedDomain.domainCname)
+          .withHeader(HeaderXSocrataHostKey, lockedDomain.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -254,7 +254,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users/boo-bear")
-          .withHeader("X-Socrata-Host", lockedDomain.domainCname)
+          .withHeader(HeaderXSocrataHostKey, lockedDomain.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -263,17 +263,17 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
       )
 
       val res = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(lockedDomain), Set(lockedDomain), Some("c=cookie"))
+        Some(lockedDomain), Set(lockedDomain), Some("c=cookie"), None)
       res should be((Some(lockedDomain), Set(lockedDomain)))
     }
 
     "remove locked domains if the user has no cookie" in {
       val relevantDomains = Set(unlockedDomain0, lockedDomain)
-      val withoutContext = domainClient.removeLockedDomainsForbiddenToUser(None, relevantDomains, None)
+      val withoutContext = domainClient.removeLockedDomainsForbiddenToUser(None, relevantDomains, None, None)
       withoutContext should be((None, Set(unlockedDomain0)))
 
       val withContext = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(unlockedDomain0), relevantDomains, None)
+        Some(unlockedDomain0), relevantDomains, None, None)
       withContext should be((Some(unlockedDomain0), Set(unlockedDomain0)))
     }
 
@@ -284,13 +284,13 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users.json")
-          .withHeader("X-Socrata-Host", unlockedDomain0.domainCname)
+          .withHeader(HeaderXSocrataHostKey, unlockedDomain0.domainCname)
       ).respond(
         response()
           .withStatusCode(401)
       )
 
-      val res = domainClient.removeLockedDomainsForbiddenToUser(Some(unlockedDomain0), relevantDomains, None)
+      val res = domainClient.removeLockedDomainsForbiddenToUser(Some(unlockedDomain0), relevantDomains, None, None)
       res should be((Some(unlockedDomain0), Set(unlockedDomain0)))
     }
 
@@ -308,7 +308,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users.json")
-          .withHeader("X-Socrata-Host", apiLockedDomain.domainCname)
+          .withHeader(HeaderXSocrataHostKey, apiLockedDomain.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -319,7 +319,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users/lazy-bear")
-          .withHeader("X-Socrata-Host", lockedDomain.domainCname)
+          .withHeader(HeaderXSocrataHostKey, lockedDomain.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -327,7 +327,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
           .withBody(CompactJsonWriter.toString(userBody))
       )
 
-      val res = domainClient.removeLockedDomainsForbiddenToUser(Some(apiLockedDomain), relevantDomains, None)
+      val res = domainClient.removeLockedDomainsForbiddenToUser(Some(apiLockedDomain), relevantDomains, None, None)
       res should be((None, Set(unlockedDomain2)))
     }
 
@@ -351,7 +351,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users.json")
-          .withHeader("X-Socrata-Host", lockedDomain.domainCname)
+          .withHeader(HeaderXSocrataHostKey, lockedDomain.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -362,7 +362,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users/boo-bear")
-          .withHeader("X-Socrata-Host", lockedDomain.domainCname)
+          .withHeader(HeaderXSocrataHostKey, lockedDomain.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -373,7 +373,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users/boo-bear")
-          .withHeader("X-Socrata-Host", doublyLockedDomain.domainCname)
+          .withHeader(HeaderXSocrataHostKey, doublyLockedDomain.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -382,28 +382,28 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
       )
 
       val res = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(lockedDomain), relevantDomains, Some("c=cookie"))
+        Some(lockedDomain), relevantDomains, Some("c=cookie"), None)
       res should be((Some(lockedDomain), Set(lockedDomain, unlockedDomain1)))
     }
 
     "return all the things if nothing is locked down" in {
-      val noContextNoDomains = domainClient.removeLockedDomainsForbiddenToUser(None, Set.empty[Domain], None)
+      val noContextNoDomains = domainClient.removeLockedDomainsForbiddenToUser(None, Set.empty[Domain], None, None)
       noContextNoDomains should be((None, Set.empty[Domain]))
 
       val noDomains = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(unlockedDomain0), Set.empty[Domain], None)
+        Some(unlockedDomain0), Set.empty[Domain], None, None)
       noDomains should be((Some(unlockedDomain0), Set.empty[Domain]))
 
-      val noContext = domainClient.removeLockedDomainsForbiddenToUser(None, Set(unlockedDomain1), None)
+      val noContext = domainClient.removeLockedDomainsForbiddenToUser(None, Set(unlockedDomain1), None, None)
       noContext should be((None, Set(unlockedDomain1)))
 
       val bothUnsharedContext = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(unlockedDomain0), Set(unlockedDomain2), None)
+        Some(unlockedDomain0), Set(unlockedDomain2), None, None)
       bothUnsharedContext should be((Some(unlockedDomain0), Set(unlockedDomain2)))
 
       val bothSharedContext = domainClient.removeLockedDomainsForbiddenToUser(
         Some(unlockedDomain1),
-        Set(unlockedDomain1, unlockedDomain2), None)
+        Set(unlockedDomain1, unlockedDomain2), None, None)
       bothSharedContext should be((Some(unlockedDomain1), Set(unlockedDomain1, unlockedDomain2)))
 
     }
@@ -423,7 +423,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users.json")
-          .withHeader("X-Socrata-Host", apiLockedDomain.domainCname)
+          .withHeader(HeaderXSocrataHostKey, apiLockedDomain.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -434,7 +434,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users/boo-bear")
-          .withHeader("X-Socrata-Host", lockedDomain.domainCname)
+          .withHeader(HeaderXSocrataHostKey, lockedDomain.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -445,7 +445,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
         request()
           .withMethod("GET")
           .withPath("/users/boo-bear")
-          .withHeader("X-Socrata-Host", doublyLockedDomain.domainCname)
+          .withHeader(HeaderXSocrataHostKey, doublyLockedDomain.domainCname)
       ).respond(
         response()
           .withStatusCode(200)
@@ -454,7 +454,7 @@ class DomainClientSpec extends WordSpec with ShouldMatchers with TestESData
       )
 
       val res = domainClient.removeLockedDomainsForbiddenToUser(
-        Some(apiLockedDomain), relevantDomains, Some("c=cookie"))
+        Some(apiLockedDomain), relevantDomains, Some("c=cookie"), None)
       res should be((Some(apiLockedDomain), relevantDomains))
     }
   }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
@@ -139,25 +139,25 @@ class CountServiceSpecWithTestESData extends FunSuiteLike with Matchers with Bef
 
   test("categories count request") {
     val expectedResults = List(Count("Personal", 4))
-    val (res, _) = service.doAggregate(CategoriesFieldType, Map.empty, None, None, None)
+    val (res, _, _) = service.doAggregate(CategoriesFieldType, Map.empty, None, None, None)
     res.results should contain theSameElementsAs expectedResults
   }
 
   test("tags count request") {
     val expectedResults = List(Count("Happy", 4), Count("Accident", 4))
-    val (res, _) = service.doAggregate(TagsFieldType, Map.empty, None, None, None)
+    val (res, _, _) = service.doAggregate(TagsFieldType, Map.empty, None, None, None)
     res.results should contain theSameElementsAs expectedResults
   }
 
   test("domain categories count request") {
     val expectedResults = List(Count("Alpha", 3), Count("Gamma", 1), Count("Fun", 2))
-    val (res, _) = service.doAggregate(DomainCategoryFieldType, Map.empty, None, None, None)
+    val (res, _, _) = service.doAggregate(DomainCategoryFieldType, Map.empty, None, None, None)
     res.results should contain theSameElementsAs expectedResults
   }
 
   test("domain tags count request") {
     val expectedResults = List(Count("1-one",3), Count("3-three",1))
-    val (res, _) = service.doAggregate(DomainTagsFieldType, Map.empty, None, None, None)
+    val (res, _, _) = service.doAggregate(DomainTagsFieldType, Map.empty, None, None, None)
     res.results should contain theSameElementsAs expectedResults
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
@@ -12,10 +12,10 @@ import org.scalamock.scalatest.proxy.MockFactory
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
 import org.springframework.mock.web.MockHttpServletResponse
 
+import com.socrata.cetera._
 import com.socrata.cetera.search._
 import com.socrata.cetera.types._
 import com.socrata.cetera.util.SearchResults
-import com.socrata.cetera.{TestCoreClient, TestESClient, TestESData, TestHttpClient}
 
 class CountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAll {
   val testSuiteName = getClass.getSimpleName.toLowerCase
@@ -139,25 +139,25 @@ class CountServiceSpecWithTestESData extends FunSuiteLike with Matchers with Bef
 
   test("categories count request") {
     val expectedResults = List(Count("Personal", 4))
-    val (res, _) = service.doAggregate(CategoriesFieldType, Map.empty, None)
+    val (res, _) = service.doAggregate(CategoriesFieldType, Map.empty, None, None, None)
     res.results should contain theSameElementsAs expectedResults
   }
 
   test("tags count request") {
     val expectedResults = List(Count("Happy", 4), Count("Accident", 4))
-    val (res, _) = service.doAggregate(TagsFieldType, Map.empty, None)
+    val (res, _) = service.doAggregate(TagsFieldType, Map.empty, None, None, None)
     res.results should contain theSameElementsAs expectedResults
   }
 
   test("domain categories count request") {
     val expectedResults = List(Count("Alpha", 3), Count("Gamma", 1), Count("Fun", 2))
-    val (res, _) = service.doAggregate(DomainCategoryFieldType, Map.empty, None)
+    val (res, _) = service.doAggregate(DomainCategoryFieldType, Map.empty, None, None, None)
     res.results should contain theSameElementsAs expectedResults
   }
 
   test("domain tags count request") {
     val expectedResults = List(Count("1-one",3), Count("3-three",1))
-    val (res, _) = service.doAggregate(DomainTagsFieldType, Map.empty, None)
+    val (res, _) = service.doAggregate(DomainTagsFieldType, Map.empty, None, None, None)
     res.results should contain theSameElementsAs expectedResults
   }
 }
@@ -176,8 +176,9 @@ class CountServiceSpecWithBrokenES extends FunSuiteLike with Matchers with MockF
     val expectedResults = """{"error":"We're sorry. Something went wrong."}"""
 
     val servReq = mock[HttpServletRequest]
-    servReq.expects('getHeader)("Cookie").returns("ricky=awesome")
-    servReq.expects('getHeader)("X-Socrata-RequestId").returns("1")
+    servReq.expects('getHeader)(HeaderCookieKey).anyNumberOfTimes.returns("ricky=awesome")
+    servReq.expects('getHeader)(HeaderXSocrataHostKey).anyNumberOfTimes.returns("opendata.test")
+    servReq.expects('getHeader)(HeaderXSocrataRequestIdKey).anyNumberOfTimes.returns("1")
     servReq.expects('getQueryString)().returns("only=datasets")
 
     val augReq = new AugmentedHttpServletRequest(servReq)

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
@@ -32,7 +32,7 @@ class DatatypeBoostSpec extends FunSuiteLike with Matchers with TestESData with 
   }
 
   test("datatype boost - increases score when datatype matches") {
-    val (results, _) = service.doSearch(Map(
+    val (results, _, _) = service.doSearch(Map(
       Params.context -> "petercetera.net",
       Params.filterDomains -> "petercetera.net,opendata-demo.socrata.com,blue.org,annabelle.island.net",
       Params.querySimple -> "one",

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/DatatypeBoostSpec.scala
@@ -3,7 +3,7 @@ package com.socrata.cetera.services
 import com.rojoma.json.v3.ast.{JNumber, JString}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
 
-import com.socrata.cetera.{TestHttpClient, TestCoreClient, TestESData, TestESClient}
+import com.socrata.cetera._
 import com.socrata.cetera.metrics.BalboaClient
 import com.socrata.cetera.search._
 import com.socrata.cetera.types._
@@ -38,7 +38,7 @@ class DatatypeBoostSpec extends FunSuiteLike with Matchers with TestESData with 
       Params.querySimple -> "one",
       Params.showScore -> "true",
       boostedDatatypeQueryString -> "10"
-    ).mapValues(Seq(_)), None)
+    ).mapValues(Seq(_)), None, None, None)
     val oneBoosted = results.results.find(_.resource.dyn.`type`.! == JString(boostedDatatype.singular)).head
     val oneOtherThing = results.results.find(_.resource.dyn.`type`.! != JString(boostedDatatype.singular)).head
 

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
@@ -31,7 +31,7 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
 
   test("domain boost of 2 should produce top result") {
     activeDomainCnames.foreach { domain =>
-      val (results, _) = service.doSearch(Map(
+      val (results, _, _) = service.doSearch(Map(
         Params.showScore -> "true",
         Params.context -> domain,
         Params.filterDomains -> activeDomainCnames.mkString(","),
@@ -42,7 +42,7 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
 
   test("domain boost of 0.5 should not produce top result") {
     activeDomainCnames.foreach { domain =>
-      val (results, _) = service.doSearch(Map(
+      val (results, _, _) = service.doSearch(Map(
         Params.showScore -> "true",
         Params.context -> domain,
         Params.filterDomains -> activeDomainCnames.mkString(","),
@@ -53,7 +53,7 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
 
   test("domain boosts are not mistaken for custom metadata") {
     activeDomainCnames.foreach { domain =>
-      val (results, _) = service.doSearch(
+      val (results, _, _) = service.doSearch(
         Map(s"""boostDomains[${domain}]""" -> "2.34",
             "boostDomains[]" -> "3.45", // if I were custom metadata, I would not match any documents
             Params.context -> domain).mapValues(Seq(_)), None, None, None
@@ -65,7 +65,7 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
   // just documenting behavior; this may not be ideal behavior
   test("boostDomains with no [] is treated as custom metadata") {
     activeDomainCnames.foreach { domain =>
-      val (results, _) = service.doSearch(
+      val (results, _, _) = service.doSearch(
         Map(s"""boostDomains[${domain}]""" -> "2.34",
             "boostDomains" -> "3.45", // interpreted as custom metadata field which doesn't match any documents
             Params.context -> domain).mapValues(Seq(_)), None, None, None

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/DomainBoostSpec.scala
@@ -35,7 +35,7 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
         Params.showScore -> "true",
         Params.context -> domain,
         Params.filterDomains -> activeDomainCnames.mkString(","),
-        s"""boostDomains[${domain}]""" -> "2").mapValues(Seq(_)), None)
+        s"""boostDomains[${domain}]""" -> "2").mapValues(Seq(_)), None, None, None)
       results.results.head.metadata(esDomainType) should be(JString(domain))
     }
   }
@@ -46,7 +46,7 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
         Params.showScore -> "true",
         Params.context -> domain,
         Params.filterDomains -> activeDomainCnames.mkString(","),
-        s"""boostDomains[${domain}]""" -> "0.5").mapValues(Seq(_)), None)
+        s"""boostDomains[${domain}]""" -> "0.5").mapValues(Seq(_)), None, None, None)
       results.results.head.metadata(esDomainType) shouldNot be(JString(domain))
     }
   }
@@ -56,7 +56,7 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
       val (results, _) = service.doSearch(
         Map(s"""boostDomains[${domain}]""" -> "2.34",
             "boostDomains[]" -> "3.45", // if I were custom metadata, I would not match any documents
-            Params.context -> domain).mapValues(Seq(_)), None
+            Params.context -> domain).mapValues(Seq(_)), None, None, None
       )
       results.results.size should be > 0
     }
@@ -68,7 +68,7 @@ class DomainBoostSpec extends FunSuiteLike with Matchers with TestESData with Be
       val (results, _) = service.doSearch(
         Map(s"""boostDomains[${domain}]""" -> "2.34",
             "boostDomains" -> "3.45", // interpreted as custom metadata field which doesn't match any documents
-            Params.context -> domain).mapValues(Seq(_)), None
+            Params.context -> domain).mapValues(Seq(_)), None, None, None
       )
       results.results should contain theSameElementsAs List.empty
     }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/DomainCountServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/DomainCountServiceSpec.scala
@@ -36,7 +36,7 @@ class DomainCountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAf
       Count("blue.org", 1),
       Count("opendata-demo.socrata.com", 1),
       Count("petercetera.net", 4))
-    val (res, _) = service.doAggregate(Map(
+    val (res, _, _) = service.doAggregate(Map(
       Params.context -> "petercetera.net",
       Params.filterDomains -> "petercetera.net,opendata-demo.socrata.com,blue.org,annabelle.island.net")
       .mapValues(Seq(_)), None, None, None)
@@ -49,7 +49,7 @@ class DomainCountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAf
       Count("blue.org", 0),
       Count("opendata-demo.socrata.com", 1),
       Count("petercetera.net", 1))
-    val (res, _) = service.doAggregate(Map(
+    val (res, _, _) = service.doAggregate(Map(
       Params.context -> "annabelle.island.net",
       Params.filterDomains -> "petercetera.net,opendata-demo.socrata.com,blue.org,annabelle.island.net")
       .mapValues(Seq(_)), None, None, None)
@@ -64,7 +64,7 @@ class DomainCountServiceSpec extends FunSuiteLike with Matchers with BeforeAndAf
       // opendata-demo.socrata.com is not a customer domain, so the domain and all docs should be hidden
       // Count("opendata-demo.socrata.com", 0),
       Count("petercetera.net", 4))
-    val (res, _) = service.doAggregate(Map.empty, None, None, None)
+    val (res, _, _) = service.doAggregate(Map.empty, None, None, None)
     res.results should contain theSameElementsAs expectedResults
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
@@ -10,9 +10,9 @@ import org.scalamock.scalatest.proxy.MockFactory
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
 import org.springframework.mock.web.MockHttpServletResponse
 
+import com.socrata.cetera._
 import com.socrata.cetera.search._
 import com.socrata.cetera.types.{FacetCount, ValueCount}
-import com.socrata.cetera.{TestCoreClient, TestESClient, TestESData, TestHttpClient}
 
 class FacetServiceSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
   val client = new TestESClient(testSuiteName)
@@ -34,7 +34,7 @@ class FacetServiceSpec extends FunSuiteLike with Matchers with TestESData with B
 
   test("retrieve all visible domain facets") {
     val (datatypes, categories, tags, facets) = domainsWithData.map { cname =>
-      val (facets, timings) = service.doAggregate(cname, None)
+      val (facets, timings) = service.doAggregate(cname, None, None)
       timings.searchMillis.headOption should be('defined)
 
       val datatypes = facets.find(_.facet == "datatypes").map(_.values).getOrElse(fail())
@@ -108,8 +108,9 @@ class FacetServiceSpecWithBrokenES extends FunSuiteLike with Matchers with MockF
     val expectedResults = """{"error":"We're sorry. Something went wrong."}"""
 
     val servReq = mock[HttpServletRequest]
-    servReq.expects('getHeader)("Cookie").returns("ricky=awesome")
-    servReq.expects('getHeader)("X-Socrata-RequestId").returns("1")
+    servReq.expects('getHeader)(HeaderCookieKey).anyNumberOfTimes.returns("ricky=awesome")
+    servReq.expects('getHeader)(HeaderXSocrataHostKey).anyNumberOfTimes.returns("opendata.test")
+    servReq.expects('getHeader)(HeaderXSocrataRequestIdKey).anyNumberOfTimes.returns("1")
     servReq.expects('getQueryString)().returns("only=datasets")
 
     val augReq = new AugmentedHttpServletRequest(servReq)

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/FacetServiceSpec.scala
@@ -34,7 +34,7 @@ class FacetServiceSpec extends FunSuiteLike with Matchers with TestESData with B
 
   test("retrieve all visible domain facets") {
     val (datatypes, categories, tags, facets) = domainsWithData.map { cname =>
-      val (facets, timings) = service.doAggregate(cname, None, None)
+      val (facets, timings, _) = service.doAggregate(cname, None, None)
       timings.searchMillis.headOption should be('defined)
 
       val datatypes = facets.find(_.facet == "datatypes").map(_.values).getOrElse(fail())

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceJettySpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceJettySpec.scala
@@ -1,0 +1,69 @@
+package com.socrata.cetera.services
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.util.Collections
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+import scala.collection.JavaConverters._
+
+import com.socrata.http.server.HttpRequest
+import com.socrata.http.server.HttpRequest.AugmentedHttpServletRequest
+import org.elasticsearch.action.search.SearchRequestBuilder
+import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.springframework.mock.web.{DelegatingServletInputStream, DelegatingServletOutputStream}
+
+import com.socrata.cetera._
+import com.socrata.cetera.metrics.BalboaClient
+import com.socrata.cetera.search.{BaseDocumentClient, BaseDomainClient}
+import com.socrata.cetera.types.NoQuery
+
+class SearchServiceJettySpec extends FunSuiteLike with Matchers with MockFactory with BeforeAndAfterAll {
+  val testSuiteName = getClass.getSimpleName.toLowerCase
+  val client = new TestESClient(testSuiteName)
+  val mockDomainClient = mock[BaseDomainClient]
+  val mockDocumentClient = mock[BaseDocumentClient]
+  val balboaClient = new BalboaClient("/tmp/metrics")
+  val service = new SearchService(mockDocumentClient, mockDomainClient, balboaClient)
+
+  override protected def afterAll(): Unit = {
+    client.close()
+  }
+
+  test("pass on any set-cookie headers in response") {
+    val expectedSetCookie = Seq("life=42", "universe=42", "everything=42")
+
+    mockDomainClient.expects('findRelevantDomains)(None, None, Some("c=cookie"), Some("1"))
+      .returns((None, Set.empty, 123L, expectedSetCookie))
+
+    mockDocumentClient.expects('buildSearchRequest)(NoQuery, Set(), None, None, None, None, None, Map(), Map(), Map(), None, None, 0, 100, None)
+      .returns(new SearchRequestBuilder(client.client))
+
+    val servReq = mock[HttpServletRequest]
+    servReq.expects('getMethod)().anyNumberOfTimes.returns("GET")
+    servReq.expects('getRequestURI)().anyNumberOfTimes.returns("/test")
+    servReq.expects('getHeaderNames)().anyNumberOfTimes.returns(Collections.emptyEnumeration[String]())
+    servReq.expects('getInputStream)().anyNumberOfTimes.returns(new DelegatingServletInputStream(new ByteArrayInputStream("".getBytes)))
+    servReq.expects('getHeader)(HeaderCookieKey).returns("c=cookie")
+    servReq.expects('getHeader)(HeaderXSocrataHostKey).anyNumberOfTimes.returns(null)
+    servReq.expects('getHeader)(HeaderXSocrataRequestIdKey).anyNumberOfTimes.returns("1")
+    servReq.expects('getQueryString)().anyNumberOfTimes.returns("")
+    servReq.expects('getRemoteHost)().anyNumberOfTimes.returns("remotehost")
+
+    val augReq = new AugmentedHttpServletRequest(servReq)
+    val httpReq = mock[HttpRequest]
+    httpReq.expects('servletRequest)().anyNumberOfTimes.returning(augReq)
+
+    val outStream = new ByteArrayOutputStream()
+    val response = mock[HttpServletResponse]
+    val status: Integer = 200
+    response.expects('setStatus)(status)
+    response.expects('setHeader)("Access-Control-Allow-Origin", "*")
+    response.expects('setContentType)("application/json; charset=UTF-8")
+    expectedSetCookie.foreach { s => response.expects('addHeader)("Set-Cookie", s)}
+    response.expects('getHeaderNames)().anyNumberOfTimes.returns(Seq("Set-Cookie").asJava)
+    response.expects('getHeaders)("Set-Cookie").anyNumberOfTimes.returns(expectedSetCookie.asJava)
+    response.expects('getOutputStream)().returns(new DelegatingServletOutputStream(outStream))
+
+    service.search(httpReq)(response)
+  }
+}

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -522,7 +522,7 @@ class SearchServiceSpecWithBrokenES extends FunSuiteLike with Matchers with Mock
     servReq.expects('getHeader)(HeaderCookieKey).returns("ricky=awesome")
     servReq.expects('getHeader)(HeaderXSocrataHostKey).anyNumberOfTimes.returns(null)
     servReq.expects('getHeader)(HeaderXSocrataRequestIdKey).anyNumberOfTimes.returns("1")
-    servReq.expects('getQueryString)().returns("only=datasets")
+    servReq.expects('getQueryString)().anyNumberOfTimes.returns("only=datasets")
 
     val augReq = new AugmentedHttpServletRequest(servReq)
 

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -359,14 +359,14 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
     //   * rejected and pending views don't show up regardless of domain setting
     //   * that the ES type returned includes only documents (i.e. no domains)
     //   * that non-customer domains don't show up
-    val (res, _) = service.doSearch(Map.empty, None, None, None)
+    val (res, _, _) = service.doSearch(Map.empty, None, None, None)
     val actualFxfs = res.results.map(_.resource.dyn.id.!.asInstanceOf[JString].string)
     actualFxfs should contain theSameElementsAs expectedFxfs
   }
 
   test("private documents should always be hidden") {
     val expectedFxfs = Set.empty
-    val (res, _) = service.doSearch(Map(
+    val (res, _, _) = service.doSearch(Map(
       Params.filterDomains -> "petercetera.net",
       Params.context -> "petercetera.net",
       Params.querySimple -> "private"
@@ -420,9 +420,9 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
     val paramsLowerCase = paramsTitleCase.mapValues(_.map(_.toLowerCase))
     val paramsUpperCase = paramsTitleCase.mapValues(_.map(_.toUpperCase))
 
-    val (resultsTitleCase, _) = service.doSearch(paramsTitleCase, None, None, None)
-    val (resultsLowerCase, _) = service.doSearch(paramsLowerCase, None, None, None)
-    val (resultsUpperCase, _) = service.doSearch(paramsUpperCase, None, None, None)
+    val (resultsTitleCase, _, _) = service.doSearch(paramsTitleCase, None, None, None)
+    val (resultsLowerCase, _, _) = service.doSearch(paramsLowerCase, None, None, None)
+    val (resultsUpperCase, _, _) = service.doSearch(paramsUpperCase, None, None, None)
 
     resultsTitleCase.results should contain theSameElementsAs resultsLowerCase.results
     resultsTitleCase.results should contain theSameElementsAs resultsUpperCase.results
@@ -437,9 +437,9 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
     val paramsLowerCase = paramsTitleCase.mapValues(_.map(_.toLowerCase))
     val paramsUpperCase = paramsTitleCase.mapValues(_.map(_.toUpperCase))
 
-    val (resultsTitleCase, _) = service.doSearch(paramsTitleCase, None, None, None)
-    val (resultsLowerCase, _) = service.doSearch(paramsLowerCase, None, None, None)
-    val (resultsUpperCase, _) = service.doSearch(paramsUpperCase, None, None, None)
+    val (resultsTitleCase, _, _) = service.doSearch(paramsTitleCase, None, None, None)
+    val (resultsLowerCase, _, _) = service.doSearch(paramsLowerCase, None, None, None)
+    val (resultsUpperCase, _, _) = service.doSearch(paramsUpperCase, None, None, None)
 
     resultsTitleCase.results should contain theSameElementsAs resultsLowerCase.results
     resultsTitleCase.results should contain theSameElementsAs resultsUpperCase.results
@@ -453,9 +453,9 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
     val paramsLowerCase = paramsTitleCase.mapValues(_.map(_.toLowerCase))
     val paramsUpperCase = paramsTitleCase.mapValues(_.map(_.toUpperCase))
 
-    val (resultsTitleCase, _) = service.doSearch(paramsTitleCase, None, None, None)
-    val (resultsLowerCase, _) = service.doSearch(paramsLowerCase, None, None, None)
-    val (resultsUpperCase, _) = service.doSearch(paramsUpperCase, None, None, None)
+    val (resultsTitleCase, _, _) = service.doSearch(paramsTitleCase, None, None, None)
+    val (resultsLowerCase, _, _) = service.doSearch(paramsLowerCase, None, None, None)
+    val (resultsUpperCase, _, _) = service.doSearch(paramsUpperCase, None, None, None)
 
     resultsTitleCase.results should contain theSameElementsAs resultsLowerCase.results
     resultsTitleCase.results should contain theSameElementsAs resultsUpperCase.results
@@ -470,9 +470,9 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
     val paramsLowerCase = paramsTitleCase.mapValues(_.map(_.toLowerCase))
     val paramsUpperCase = paramsTitleCase.mapValues(_.map(_.toUpperCase))
 
-    val (resultsTitleCase, _) = service.doSearch(paramsTitleCase, None, None, None)
-    val (resultsLowerCase, _) = service.doSearch(paramsLowerCase, None, None, None)
-    val (resultsUpperCase, _) = service.doSearch(paramsUpperCase, None, None, None)
+    val (resultsTitleCase, _, _) = service.doSearch(paramsTitleCase, None, None, None)
+    val (resultsLowerCase, _, _) = service.doSearch(paramsLowerCase, None, None, None)
+    val (resultsUpperCase, _, _) = service.doSearch(paramsUpperCase, None, None, None)
 
     resultsTitleCase.results should contain theSameElementsAs resultsLowerCase.results
     resultsTitleCase.results should contain theSameElementsAs resultsUpperCase.results
@@ -480,7 +480,7 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
 
   test("sorting by name works") {
     val params = Map("order" -> Seq("name"))
-    val (results, _) = service.doSearch(params, None, None, None)
+    val (results, _, _) = service.doSearch(params, None, None, None)
     val expected = results.results.map(_.resource.dyn("name").!.asInstanceOf[JString].string).sorted.head
     val firstResult = results.results.head.resource.dyn("name").? match {
       case Right(n) => n should be (JString(expected))
@@ -490,7 +490,7 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
 
   test("sorting by name DESC works") {
     val params = Map("order" -> Seq("name DESC"))
-    val (results, _) = service.doSearch(params, None, None, None)
+    val (results, _, _) = service.doSearch(params, None, None, None)
     val expected = results.results.map(_.resource.dyn("name").!.asInstanceOf[JString].string).sorted.last
     val firstResult = results.results.head.resource.dyn("name").? match {
       case Right(n) => n should be (JString(expected))

--- a/cetera-http/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/util/QueryParametersParserSpec.scala
@@ -72,7 +72,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
 
         "boostTitle" -> "9.0",
         "boostDesc" -> "8.0"
-      ).mapValues(Seq(_)))
+      ).mapValues(Seq(_)), None)
 
     vqps match {
       case Left(_) => fail("a ValidatedQueryParameters should be returned")
@@ -96,28 +96,28 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
   }
 
   test("no datatype boost params results in empty datatype boosts map") {
-    QueryParametersParser(Map("query" -> "crime").mapValues(Seq(_))) match {
+    QueryParametersParser(Map("query" -> "crime").mapValues(Seq(_)), None) match {
       case Right(params) => params.datatypeBoosts should have size 0
       case _ => fail()
     }
   }
 
   test("malformed datatype boost params result in empty datatype boosts map") {
-    QueryParametersParser(Map("query" -> "crime", "boostsDatasets" -> "5.0").mapValues(Seq(_))) match {
+    QueryParametersParser(Map("query" -> "crime", "boostsDatasets" -> "5.0").mapValues(Seq(_)), None) match {
       case Right(params) => params.datatypeBoosts should have size 0
       case _ => fail()
     }
   }
 
   test("well-formed datatype boost params validate") {
-    QueryParametersParser(Map("query" -> "crime", "boostDatasets" -> "5.0", "boostMaps" -> "2.0").mapValues(Seq(_))) match {
+    QueryParametersParser(Map("query" -> "crime", "boostDatasets" -> "5.0", "boostMaps" -> "2.0").mapValues(Seq(_)), None) match {
       case Right(params) => params.datatypeBoosts should have size 2
       case _ => fail()
     }
   }
 
   test("allow category with commas") {
-    QueryParametersParser(Map("categories" -> "Traffic, Parking, and Transportation").mapValues(Seq(_))) match {
+    QueryParametersParser(Map("categories" -> "Traffic, Parking, and Transportation").mapValues(Seq(_)), None) match {
       case Right(params) =>
         params.categories should be('defined)
         params.categories.get should have size 1
@@ -127,7 +127,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
   }
 
   test("allow tag with commas") {
-    QueryParametersParser(Map("tags" -> "this, probably, doesn't, happen, on, any, customer, sites").mapValues(Seq(_))) match {
+    QueryParametersParser(Map("tags" -> "this, probably, doesn't, happen, on, any, customer, sites").mapValues(Seq(_)), None) match {
       case Right(params) =>
         params.tags should be('defined)
         params.tags.get should have size 1
@@ -137,7 +137,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
   }
 
   test("allow multiple category parameters") {
-    QueryParametersParser(Map("categories" -> Seq("Traffic", "Parking", "Transportation"))) match {
+    QueryParametersParser(Map("categories" -> Seq("Traffic", "Parking", "Transportation")), None) match {
       case Right(params) =>
         params.categories should be('defined)
         params.categories.get should have size 3
@@ -147,7 +147,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
   }
 
   test("allow multiple tag parameters") {
-    QueryParametersParser(Map("tags" -> Seq("Traffic", "Parking", "Transportation"))) match {
+    QueryParametersParser(Map("tags" -> Seq("Traffic", "Parking", "Transportation")), None) match {
       case Right(params) =>
         params.tags should be('defined)
         params.tags.get should have size 3
@@ -157,7 +157,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
   }
 
   test("also allow categories[] parameters") {
-    QueryParametersParser(Map("categories" -> Seq("foo", "foos"), "categories[]" -> Seq("bar", "baz"))) match {
+    QueryParametersParser(Map("categories" -> Seq("foo", "foos"), "categories[]" -> Seq("bar", "baz")), None) match {
       case Right(params) =>
         params.categories should be('defined)
         params.categories.get should have size 4
@@ -167,7 +167,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
   }
 
   test("also allow tags[] parameters") {
-    QueryParametersParser(Map("tags" -> Seq("foo", "foos"), "tags[]" -> Seq("bar", "baz"))) match {
+    QueryParametersParser(Map("tags" -> Seq("foo", "foos"), "tags[]" -> Seq("bar", "baz")), None) match {
       case Right(params) =>
         params.tags should be('defined)
         params.tags.get should have size 4
@@ -261,7 +261,8 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
         knownNumericParams ++
         knownStringParams ++
         knownArrayParams ++
-        domainBoostExamples
+        domainBoostExamples,
+      None
     ) match {
       case Right(params) =>
         params.domainMetadata shouldNot be('defined)
@@ -271,7 +272,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
 
   // just documenting that we do not support boostDomains without the []
   test ("boostDomains without [] gets interpreted as custom metadata") {
-    QueryParametersParser(Map("boostDomains" -> Seq("1.23"), "pants" -> Seq("2.34"))) match {
+    QueryParametersParser(Map("boostDomains" -> Seq("1.23"), "pants" -> Seq("2.34")), None) match {
       case Right(params) => params.domainMetadata match {
         case Some(metadata) => metadata should be(Set("boostDomains" -> "1.23", "pants" -> "2.34"))
         case None => fail("expected to see boostDomains show up in metadata")
@@ -282,7 +283,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
 
   // empty query string param is passed in from socrata-http multi params sometimes, e.g. catalog?q=bikes&
   test("handle empty query string param key") {
-    QueryParametersParser(Map("" -> Seq())) match {
+    QueryParametersParser(Map("" -> Seq()), None) match {
       case Right(params) => ()
       case _ => fail()
     }
@@ -290,7 +291,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
 
   // empty query string param is passed in from socrata-http multi params sometimes, e.g. catalog?q=bikes&one+extra
   test("handle empty query string param value") {
-    QueryParametersParser(Map("one extra" -> Seq())) match {
+    QueryParametersParser(Map("one extra" -> Seq()), None) match {
       case Right(params) => ()
       case _ => fail()
     }
@@ -302,7 +303,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
       "boostDomains[data.seattle.gov]" -> Seq("4.56")
     )
 
-    QueryParametersParser(domainBoosts) match {
+    QueryParametersParser(domainBoosts, None) match {
       case Right(params) => params.domainBoosts should be(
         Map("example.com" -> 1.23f, "data.seattle.gov" -> 4.56f)
       )
@@ -316,7 +317,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
       "boostDomains[data.seattle.gov]" -> Seq("4.56")
     )
 
-    QueryParametersParser(domainBoosts) match {
+    QueryParametersParser(domainBoosts, None) match {
       case Right(params) => params.domainBoosts should be(Map("data.seattle.gov" -> 4.56f))
       case _ => fail()
     }
@@ -330,7 +331,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
       "boostDomains[]" -> Seq()
     )
 
-    QueryParametersParser(domainBoosts) match {
+    QueryParametersParser(domainBoosts, None) match {
       case Right(params) => params.domainBoosts should be(Map("data.seattle.gov" -> 4.56f))
       case _ => fail()
     }
@@ -341,7 +342,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
       "boostDomains[boostDomains[example.com]]" -> Seq("1.23")
     )
 
-    QueryParametersParser(domainBoosts) match {
+    QueryParametersParser(domainBoosts, None) match {
       case Right(params) => params.domainBoosts should be(Map("boostDomains[example.com]" -> 1.23f))
       case _ => fail()
     }
@@ -353,7 +354,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
       Params.boostDomains + "[example.com]" -> Seq("1.23")
     )
 
-    QueryParametersParser(params) match {
+    QueryParametersParser(params, None) match {
       case Right(p) => p.domainBoosts should be(Map("example.com" -> 1.23f))
       case _ => fail()
     }
@@ -367,7 +368,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
       Params.boostDomains -> Seq("1.23")
     )
 
-    QueryParametersParser(params) match {
+    QueryParametersParser(params, None) match {
       case Right(p) => p.domainBoosts should be(Map.empty[String, Float])
       case _ => fail()
     }
@@ -376,7 +377,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
   test("sort order can be parsed") {
     val sortOrder = Map("order" -> Seq("page_views_total"))
 
-    QueryParametersParser(sortOrder) match {
+    QueryParametersParser(sortOrder, None) match {
       case Right(params) => params.sortOrder should be(Some("page_views_total"))
       case _ => fail()
     }
@@ -385,7 +386,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
   test("an upper bound of 10000 is imposed on the limit parameter") {
     val limit = Map("limit" -> Seq("100000"))
 
-    QueryParametersParser(limit) match {
+    QueryParametersParser(limit, None) match {
       case Right(params) => params.limit should be(10000)
       case _ => fail()
     }
@@ -394,7 +395,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
   test("a limit param of less than 10000 is allowed") {
     val limit = Map("limit" -> Seq("100"))
 
-    QueryParametersParser(limit) match {
+    QueryParametersParser(limit, None) match {
       case Right(params) => params.limit should be(100)
       case _ => fail()
     }

--- a/cetera-perf/src/main/scala/com/socrata/cetera/CatalogSearchBenchmark.scala
+++ b/cetera-perf/src/main/scala/com/socrata/cetera/CatalogSearchBenchmark.scala
@@ -77,11 +77,11 @@ class CatalogSearchBenchmark {
 
   @Benchmark
   def searchDomain(): Unit = {
-    domainCnames.foreach(c => domainClient.findRelevantDomains(Some(c), None, None))
+    domainCnames.foreach(c => domainClient.findRelevantDomains(Some(c), None, None, None))
   }
 
   @Benchmark
   def query(): Unit = {
-    queryParameters.foreach(q => searchService.doSearch(q, None))
+    queryParameters.foreach(q => searchService.doSearch(q, None, None, None))
   }
 }

--- a/configs/sample-cetera.conf
+++ b/configs/sample-cetera.conf
@@ -1,3 +1,4 @@
 com.socrata {
   cetera.port = 5704
+  core.host = "127.0.0.1"
 }


### PR DESCRIPTION
When we look up a user for authentication, we have a chance to connect
all related transatctions by request id.

second piece todo still: pass Set-Cookie headers from core back to the requester.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socrata/cetera/155)
<!-- Reviewable:end -->
