### PR TITLE
EN-6279 users

### DIFF
--- a/cetera-http/src/main/resources/esMappings.json
+++ b/cetera-http/src/main/resources/esMappings.json
@@ -4,6 +4,9 @@
       "_parent" : {
         "type" : "domain"
       },
+      "_routing" : {
+        "required" : true
+      },
       "properties" : {
         "fts_analyzed" : {
           "type": "string",
@@ -44,10 +47,12 @@
           "type" : "float"
         },
         "updated_at" : {
-            "type" : "date"
+          "type" : "date",
+          "format" : "dateOptionalTime"
         },
         "created_at" : {
-            "type" : "date"
+          "type" : "date",
+          "format" : "dateOptionalTime"
         },
         "page_views" : {
           "properties": {
@@ -78,7 +83,7 @@
               "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
                 "raw" : {"type" : "string", "index" : "not_analyzed"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
               }
             },
             "columns_name" : {
@@ -86,7 +91,7 @@
               "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
                 "raw" : {"type" : "string", "index" : "not_analyzed"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
               }
             },
             "columns_field_name" : {
@@ -94,7 +99,7 @@
               "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
                 "raw" : {"type" : "string", "index" : "not_analyzed"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
               }
             },
             "description" : {
@@ -102,7 +107,7 @@
               "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
                 "raw" : {"type" : "string", "index" : "not_analyzed"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
               }
             },
             "name" : {
@@ -110,7 +115,7 @@
               "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
                 "raw" : {"type" : "string", "index" : "not_analyzed"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
               }
             }
           },
@@ -146,10 +151,12 @@
               "type" : "string"
             },
             "updatedAt" : {
-              "type" : "date"
+              "type" : "date",
+              "format" : "dateOptionalTime"
             },
             "createdAt" : {
-              "type" : "date"
+              "type" : "date",
+              "format" : "dateOptionalTime"
             },
             "type" : {
               "type" : "string"
@@ -162,7 +169,7 @@
               "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
                 "raw" : {"type" : "string", "index" : "not_analyzed"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
               }
             },
             "columns_name" : {
@@ -170,7 +177,7 @@
               "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
                 "raw" : {"type" : "string", "index" : "not_analyzed"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
               }
             },
             "columns_field_name" : {
@@ -178,7 +185,7 @@
               "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
                 "raw" : {"type" : "string", "index" : "not_analyzed"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
               }
             }
           }
@@ -204,11 +211,11 @@
                   "analyzer": "case_insensitive_en",
                   "copy_to": [ "fts_analyzed", "fts_raw" ],
                   "fields" : {
-                    "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
-                    "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                    "raw" : {"type" : "string", "index" : "not_analyzed", "store" : true},
+                    "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
                   }
                 },
-                "score" : {"type" : "float", "store" : "no", "index" : "not_analyzed"}
+                "score" : {"type" : "float"}
               }
             },
             "tags" : {
@@ -219,11 +226,11 @@
                   "analyzer": "case_insensitive_en",
                   "copy_to": [ "fts_analyzed", "fts_raw" ],
                   "fields" : {
-                    "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
-                    "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                    "raw" : {"type" : "string", "index" : "not_analyzed", "store" : true},
+                    "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
                   }
                 },
-                "score" : {"type" : "float", "store" : "no", "index" : "not_analyzed"}
+                "score" : {"type" : "float"}
               }
             }
           }
@@ -234,7 +241,7 @@
           "copy_to": [ "fts_analyzed", "fts_raw" ],
           "fields": {
             "raw" : {"type" : "string", "index" : "not_analyzed"},
-            "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+            "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
           }
         },
         "customer_category" : {
@@ -243,7 +250,7 @@
           "copy_to": [ "fts_analyzed", "fts_raw" ],
           "fields" : {
             "raw" : {"type" : "string", "index" : "not_analyzed"},
-            "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+            "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
           }
         },
         "customer_metadata_flattened" : {
@@ -253,16 +260,16 @@
               "type" : "string",
               "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                "raw" : {"type" : "string", "index" : "not_analyzed", "store" : true},
+                "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
               }
             },
             "value" : {
               "type" : "string",
               "copy_to": [ "fts_analyzed", "fts_raw" ],
               "fields" : {
-                "raw" : {"type" : "string", "store" : "yes", "index" : "not_analyzed"},
-                "analyzed" : {"type" : "string", "index" : "analyzed", "analyzer" : "snowball_en"}
+                "raw" : {"type" : "string", "index" : "not_analyzed", "store" : true},
+                "analyzed" : {"type" : "string", "analyzer" : "snowball_en"}
               }
             }
           }
@@ -275,14 +282,16 @@
             },
             "screen_name": {
               "type": "string",
-              "analyzer": "case_insensitive_en",
+              "analyzer": "screen_name",
               "fields": {
-                "analyzed": { "type": "string", "analyzer": "snowball_en" },
                 "raw": { "type": "string", "index": "not_analyzed" }
-              },
-              "copy_to": [ "fts_analyzed", "fts_raw" ]
+              }
             }
           }
+        },
+        "shared_to" : {
+          "type" : "string",
+          "index" : "not_analyzed"
         }
       }
     },
@@ -339,6 +348,53 @@
         },
         "api_locked_down" : {
           "type" : "boolean"
+        }
+      }
+    },
+    "user" : {
+      "properties" : {
+        "id" : {
+          "type" : "string",
+          "index" : "not_analyzed"
+        },
+        "screen_name" : {
+          "type" : "string",
+          "analyzer" : "screen_name",
+          "fields" : {
+            "raw" : { "type" : "string", "index" : "not_analyzed" }
+          }
+        },
+        "email" : {
+          "type" : "string",
+          "analyzer" : "email",
+          "fields" : {
+            "raw" : { "type" : "string", "index" : "not_analyzed" }
+          }
+        },
+        "roles" : {
+          "type" : "nested",
+          "properties" : {
+            "domain_id" : {
+              "type" : "long",
+              "index" : "not_analyzed"
+            },
+            "role_name" : {
+              "type" : "string",
+              "index" : "not_analyzed"
+            }
+          }
+        },
+        "profile_image_url_large" : {
+          "type" : "string",
+          "index" : "no"
+        },
+        "profile_image_url_medium" : {
+          "type" : "string",
+          "index" : "no"
+        },
+        "profile_image_url_small" : {
+          "type" : "string",
+          "index" : "no"
         }
       }
     }

--- a/cetera-http/src/main/resources/esSettings.json
+++ b/cetera-http/src/main/resources/esSettings.json
@@ -3,21 +3,59 @@
     "index": {
       "analysis": {
         "filter": {
+          "email": {
+            "type": "pattern_capture",
+            "preserve_original": 0,
+            "patterns": [
+              "([^@]+)",
+              "(\\p{L}{2,})",
+              "(\\d+)",
+              "@(.{2,})"
+            ]
+          },
           "lowercase_en": {
             "type": "lowercase"
+          },
+          "stopwords": {
+            "type": "stop",
+            "stopwords": "_english_"
+          }
+        },
+        "tokenizer": {
+          "word": {
+            "type": "pattern",
+            "pattern": "[\\p{C}\\p{P}\\p{Sm}\\p{Sk}\\p{So}\\p{Z}&&[^\\&]]+",
+            "flags": "CASE_INSENSITIVE"
           }
         },
         "analyzer": {
-          "snowball_en": {
-            "type": "snowball",
-            "language": "English"
-          },
           "case_insensitive_en": {
             "type": "custom",
             "filter": [
               "lowercase_en"
             ],
             "tokenizer": "keyword"
+          },
+          "email": {
+            "tokenizer": "uax_url_email",
+            "filter": [
+              "email",
+              "lowercase_en",
+              "unique",
+              "stopwords"
+            ]
+          },
+          "screen_name": {
+            "tokenizer": "word",
+            "filter": [
+              "lowercase_en",
+              "unique",
+              "stopwords"
+            ]
+          },
+          "snowball_en": {
+            "type": "snowball",
+            "language": "English"
           }
         }
       },

--- a/cetera-http/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -94,8 +94,8 @@ object SearchServer extends App {
     logger.info("Initializing CountService with document and domain clients")
     val countService = new CountService(documentClient, domainClient)
 
-    logger.info("Initializing UserSearchService with user client")
-    val userSearchService = new UserSearchService(userClient)
+    logger.info("Initializing UserSearchService with user and core clients")
+    val userSearchService = new UserSearchService(userClient, coreClient)
 
     logger.info("Initializing router with services")
     val router = new Router(

--- a/cetera-http/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -15,7 +15,7 @@ import com.socrata.cetera.authentication.CoreClient
 import com.socrata.cetera.config.CeteraConfig
 import com.socrata.cetera.handlers.Router
 import com.socrata.cetera.metrics.BalboaClient
-import com.socrata.cetera.search.{DocumentClient, DomainClient, ElasticSearchClient}
+import com.socrata.cetera.search.{DocumentClient, DomainClient, ElasticSearchClient, UserClient}
 import com.socrata.cetera.services._
 import com.socrata.cetera.types.ScriptScoreFunction
 
@@ -71,6 +71,7 @@ object SearchServer extends App {
       config.elasticSearch.functionScoreScripts.flatMap(fnName =>
       ScriptScoreFunction.getScriptFunction(fnName)).toSet
     )
+    val userClient = new UserClient(esClient, config.elasticSearch.indexAliasName)
 
     logger.info("ElasticSearchClient initialized on nodes " +
                   esClient.client.asInstanceOf[TransportClient].transportAddresses().toString)
@@ -93,13 +94,17 @@ object SearchServer extends App {
     logger.info("Initializing CountService with document and domain clients")
     val countService = new CountService(documentClient, domainClient)
 
+    logger.info("Initializing UserSearchService with user client")
+    val userSearchService = new UserSearchService(userClient)
+
     logger.info("Initializing router with services")
     val router = new Router(
       versionService.Service,
       searchService.Service,
       facetService.Service,
       domainCountService.Service,
-      countService.Service
+      countService.Service,
+      userSearchService.Service
     )
 
     logger.info("Initializing handler")

--- a/cetera-http/src/main/scala/com/socrata/cetera/authentication/User.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/authentication/User.scala
@@ -7,12 +7,12 @@ case class User(id: String,
                 rights: Option[Seq[String]],
                 flags: Option[Seq[String]]) {
 
-  def canViewCatalog: Boolean = {
-    val isAdmin = flags.exists(_.contains("admin"))
-    val hasRole = roleName.nonEmpty
+  def isAdmin: Boolean = flags.exists(_.contains("admin"))
+  def hasRole: Boolean = roleName.nonEmpty
+  def hasRole(role: String): Boolean = roleName.contains(role)
 
-    hasRole || isAdmin
-  }
+  def canViewCatalog: Boolean = hasRole || isAdmin
+  def canViewUsers: Boolean = hasRole("administrator") || isAdmin
 }
 
 object User {

--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/Router.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/Router.scala
@@ -16,7 +16,8 @@ class Router(
     catalogResource: => HttpService,
     facetResource: String => HttpService,
     domainCountResource: => HttpService,
-    countResource: DocumentFieldType with Countable with Rawable => HttpService) {
+    countResource: DocumentFieldType with Countable with Rawable => HttpService,
+    userSearchResource: => HttpService) {
 
   val routes = Routes(
     // /version is for internal use
@@ -48,7 +49,11 @@ class Router(
 
     // document counts for queries grouped by domain_tags
     Route("/catalog/domain_tags", countResource(DomainTagsFieldType)),
-    Route("/catalog/v1/domain_tags", countResource(DomainTagsFieldType))
+    Route("/catalog/v1/domain_tags", countResource(DomainTagsFieldType)),
+
+    // internal user search
+    Route("/users", userSearchResource),
+    Route("/users/v1", userSearchResource)
   )
 
   def route(req: HttpRequest): HttpResponse =

--- a/cetera-http/src/main/scala/com/socrata/cetera/package.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/package.scala
@@ -11,4 +11,5 @@ package object cetera {
 
   val esDocumentType = "document"
   val esDomainType = "domain"
+  val esUserType = "user"
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/UserClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/UserClient.scala
@@ -1,0 +1,57 @@
+package com.socrata.cetera.search
+
+import com.rojoma.json.v3.util.JsonUtil
+import org.elasticsearch.index.query.QueryBuilders
+import org.slf4j.LoggerFactory
+
+import com.socrata.cetera._
+import com.socrata.cetera.types._
+import com.socrata.cetera.util.{JsonDecodeException, LogHelper}
+
+trait BaseUserClient {
+  def fetch(id: String): Option[User]
+  def search(q: Option[String]): (Set[User], Long)
+}
+
+class UserClient(esClient: ElasticSearchClient, indexAliasName: String) extends BaseUserClient {
+  val logger = LoggerFactory.getLogger(getClass)
+
+  def fetch(id: String): Option[User] = {
+    val get = esClient.client.prepareGet(indexAliasName, esUserType, id)
+    logger.info("Elasticsearch request: " + get.request.toString)
+
+    val res = get.execute.actionGet
+    User(res.getSourceAsString)
+  }
+
+  def search(query: Option[String]): (Set[User], Long) = {
+    val baseQuery = query match {
+      case None => QueryBuilders.matchAllQuery()
+      case Some(q) =>
+        QueryBuilders
+          .queryStringQuery(q)
+          .field(ScreenName.fieldName)
+          .field(ScreenName.rawFieldName)
+          .field(Email.fieldName)
+          .field(Email.rawFieldName)
+          .autoGeneratePhraseQueries(true)
+    }
+    val req = esClient.client.prepareSearch(indexAliasName)
+      .setTypes(esUserType)
+      .setQuery(baseQuery)
+    logger.info(LogHelper.formatEsRequest(req))
+
+    val res = req.execute.actionGet
+    val timing = res.getTookInMillis
+    val users = res.getHits.hits.flatMap { h =>
+      JsonUtil.parseJson[User](h.sourceAsString) match {
+        case Right(u) => Some(u)
+        case Left(err) =>
+          logger.error(err.english)
+          throw new JsonDecodeException(err)
+      }
+    }.toSet
+
+    (users, timing)
+  }
+}

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/UserSearchService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/UserSearchService.scala
@@ -1,0 +1,65 @@
+package com.socrata.cetera.services
+
+import scala.util.control.NonFatal
+
+import com.socrata.http.server._
+import com.socrata.http.server.implicits._
+import com.socrata.http.server.responses._
+import com.socrata.http.server.routing.SimpleResource
+import org.slf4j.LoggerFactory
+
+import com.socrata.cetera._
+import com.socrata.cetera.search.UserClient
+import com.socrata.cetera.types.User
+import com.socrata.cetera.util.JsonResponses._
+import com.socrata.cetera.util.{InternalTimings, SearchResults, Timings, _}
+
+class UserSearchService(userClient: UserClient) {
+  lazy val logger = LoggerFactory.getLogger(getClass)
+
+  def doSearch(
+      queryParameters: MultiQueryParams,
+      cookie: Option[String],
+      extendedHost: Option[String],
+      requestId: Option[String])
+  : (SearchResults[User], InternalTimings, Seq[String]) = {
+    val now = Timings.now()
+
+    val query: Option[String] = queryParameters.getOrElse("q", Seq.empty).headOption
+    val (results, timing) = userClient.search(query)
+
+    val formattedResults: SearchResults[User] = new SearchResults[User](results.toSeq)
+    val timings = InternalTimings(Timings.elapsedInMillis(now), Seq(timing))
+
+    (formattedResults.copy(resultSetSize = Some(results.size), timings = Some(timings)), timings)
+  }
+
+  // $COVERAGE-OFF$ jetty wiring
+  def search(req: HttpRequest): HttpResponse = {
+    logger.debug(LogHelper.formatHttpRequestVerbose(req))
+
+    val cookie = req.header(HeaderCookieKey)
+    val extendedHost = req.header(HeaderXSocrataHostKey)
+    val requestId = req.header(HeaderXSocrataRequestIdKey)
+
+    try {
+      val (formattedResults, timings) = doSearch(req.multiQueryParams, cookie, extendedHost, requestId)
+      logger.info(LogHelper.formatRequest(req, timings))
+      Http.decorate(Json(formattedResults, pretty = true), OK, Seq.empty)
+    } catch {
+      case e: IllegalArgumentException =>
+        logger.info(e.getMessage)
+        BadRequest ~> HeaderAclAllowOriginAll ~> jsonError(e.getMessage)
+      case NonFatal(e) =>
+        val msg = "Cetera search service error"
+        val esError = ElasticsearchError(e)
+        logger.error(s"$msg: $esError")
+        InternalServerError ~> HeaderAclAllowOriginAll ~> jsonError("We're sorry. Something went wrong.")
+    }
+  }
+
+  object Service extends SimpleResource {
+    override def get: HttpService = search
+  }
+  // $COVERAGE-ON$
+}

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -12,6 +12,7 @@ sealed trait CeteraFieldType {
 
 sealed trait DocumentFieldType extends CeteraFieldType
 sealed trait DomainFieldType extends CeteraFieldType
+sealed trait UserFieldType extends CeteraFieldType
 
 // A field that can be boosted (i.e, fields like title or description that can
 // have extra weight given to then when matching keyword queries).
@@ -231,4 +232,16 @@ case object CreatedAtFieldType extends DocumentFieldType with Sortable {
 
 case object NameFieldType extends DocumentFieldType with Sortable {
   val fieldName: String = "indexed_metadata.name.raw"
+}
+
+
+////////////////
+// U'sarians
+
+case object ScreenName extends UserFieldType with Rawable {
+  val fieldName: String = "screen_name"
+}
+
+case object Email extends UserFieldType with Rawable {
+  val fieldName: String = "email"
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/User.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/User.scala
@@ -1,0 +1,31 @@
+package com.socrata.cetera.types
+
+import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonKeyStrategy, JsonUtil, Strategy}
+import org.slf4j.LoggerFactory
+
+import com.socrata.cetera.util.JsonDecodeException
+
+@JsonKeyStrategy(Strategy.Underscore)
+case class User(id: String,
+                screenName: Option[String],
+                email: Option[String],
+                roleName: Option[String],
+                profileImageUrlLarge: Option[String],
+                profileImageUrlMedium: Option[String],
+                profileImageUrlSmall: Option[String])
+
+object User {
+  implicit val codec = AutomaticJsonCodecBuilder[User]
+  val logger = LoggerFactory.getLogger(getClass)
+
+  def apply(source: String): Option[User] = {
+    Option(source).flatMap { s =>
+      JsonUtil.parseJson[User](s) match {
+        case Right(user) => Some(user)
+        case Left(err) =>
+          logger.error(err.english)
+          throw new JsonDecodeException(err)
+      }
+    }
+  }
+}

--- a/cetera-http/src/main/scala/com/socrata/cetera/util/ElasticsearchBootstrap.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/util/ElasticsearchBootstrap.scala
@@ -9,7 +9,6 @@ import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
 import com.socrata.cetera._
-import com.socrata.cetera.config.ElasticSearchConfig
 import com.socrata.cetera.search.ElasticSearchClient
 
 object ElasticsearchBootstrap {
@@ -30,8 +29,9 @@ object ElasticsearchBootstrap {
     }
     val mappings = sj.dyn.mappings
     val typeMapping = datatype match {
-      case s: String if s == "domain" => mappings.domain
       case s: String if s == "document" => mappings.document
+      case s: String if s == "domain" => mappings.domain
+      case s: String if s == "user" => mappings.user
     }
     typeMapping.!.toString()
   }
@@ -57,6 +57,11 @@ object ElasticsearchBootstrap {
         client.client.admin.indices.preparePutMapping(index)
           .setType(esDocumentType)
           .setSource(datatypeMappings(esDocumentType))
+          .execute.actionGet
+
+        client.client.admin.indices.preparePutMapping(index)
+          .setType(esUserType)
+          .setSource(datatypeMappings(esUserType))
           .execute.actionGet
 
         logger.info(s"aliasing $indexAliasName -> $index")

--- a/cetera-http/src/test/resources/users.tsv
+++ b/cetera-http/src/test/resources/users.tsv
@@ -1,0 +1,2 @@
+id	displayName	email	roleName	imageLarge	imageMedium	imageSmall
+soul-eater	death-the-kid	death.kid@deathcity.com	headmaster	/api/users/soul-eater/profile_images/LARGE	/api/users/soul-eater/profile_images/THUMB	/api/users/soul-eater/profile_images/TINY

--- a/cetera-http/src/test/scala/com/socrata/cetera/authentication/UserSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/authentication/UserSpec.scala
@@ -3,21 +3,35 @@ package com.socrata.cetera.authentication
 import org.scalatest.{WordSpec, ShouldMatchers}
 
 class UserSpec extends WordSpec with ShouldMatchers {
+  val superAdmin = User("", None, None, Some(List("admin")))
+  val customerAdmin = User("", Some("administrator"), None, None)
+  val anonymous = User("", None, None, None)
 
   "The canViewCatalog method" should {
     "return true if the user is an admin" in {
-      val user = User("", None, None, Some(List("admin")))
-      user.canViewCatalog should be(true)
+      superAdmin.canViewCatalog should be(true)
     }
 
     "return true if the user has a role" in {
-      val user = User("", Some("administrator"), None, None)
-      user.canViewCatalog should be(true)
+      customerAdmin.canViewCatalog should be(true)
     }
 
     "return false if the user isn't an admin and hasn't a role" in {
-      val user = User("", None, None, None)
-      user.canViewCatalog should be(false)
+      anonymous.canViewCatalog should be(false)
+    }
+  }
+
+  "The canViewUsers method" should {
+    "return true if the use is a super admin" in {
+      superAdmin.canViewUsers should be(true)
+    }
+
+    "return true if the use is a customer admin" in {
+      customerAdmin.canViewUsers should be(true)
+    }
+
+    "return false if the use is neither type of admin" in {
+      anonymous.canViewUsers should be(false)
     }
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/UserClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/UserClientSpec.scala
@@ -1,0 +1,82 @@
+package com.socrata.cetera.search
+
+import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+
+import com.socrata.cetera.{TestESClient, TestESData}
+
+class UserClientSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
+  val client = new TestESClient(testSuiteName)
+  val userClient = new UserClient(client, testSuiteName)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    bootstrapData()
+  }
+
+  override protected def afterAll(): Unit = {
+    removeBootstrapData()
+    client.close()
+    super.beforeAll()
+  }
+
+  test("fetch user by non-existent id, get a None") {
+    val user = userClient.fetch("dead-beef")
+    user should be('empty)
+  }
+
+  test("fetch user by id") {
+    val expectedId = "soul-eater"
+    val user = userClient.fetch(expectedId)
+
+    user should be('defined)
+    user.get.id should be(expectedId)
+
+    user.get.screenName should be('defined)
+    user.get.screenName.get should be("death-the-kid")
+
+    user.get.email should be('defined)
+    user.get.email.get should be("death.kid@deathcity.com")
+
+    user.get.roleName should be('defined)
+    user.get.roleName.get should be("headmaster")
+
+    user.get.profileImageUrlLarge should be('defined)
+    user.get.profileImageUrlLarge.get should be("/api/users/soul-eater/profile_images/LARGE")
+
+    user.get.profileImageUrlMedium should be('defined)
+    user.get.profileImageUrlMedium.get should be("/api/users/soul-eater/profile_images/THUMB")
+
+    user.get.profileImageUrlSmall should be('defined)
+    user.get.profileImageUrlSmall.get should be("/api/users/soul-eater/profile_images/TINY")
+  }
+
+  test("search returns all by default") {
+    val (users, _) = userClient.search(None)
+    users.headOption should be('defined)
+  }
+
+  test("search for user by exact name") {
+    val (users, _) = userClient.search(Some("death-the-kid"))
+    users.headOption should be('defined)
+  }
+
+  test("search for user by partial name") {
+    val (users, _) = userClient.search(Some("death"))
+    users.headOption should be('defined)
+  }
+
+  test("search for user by exact email") {
+    val (users, _) = userClient.search(Some("death.kid@deathcity.com"))
+    users.headOption should be('defined)
+  }
+
+  test("search for user by email alias") {
+    val (users, _) = userClient.search(Some("death.kid"))
+    users.headOption should be('defined)
+  }
+
+  test("search for user by email domain") {
+    val (users, _) = userClient.search(Some("deathcity.com"))
+    users.headOption should be('defined)
+  }
+}

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -424,7 +424,8 @@ class SearchServiceSpecWithTestData extends FunSuiteLike with Matchers with Test
     actualFxfs should contain theSameElementsAs expectedFxfs
   }
 
-  test("if a user's name is queried, datasets with a matching owner:screen_name should show up") {
+  // TODO: consider searching for datasets by user screen name; using new custom analyzer
+  ignore("if a user's name is queried, datasets with a matching owner:screen_name should show up") {
     val params = Map(
       "q" -> "John"
     ).mapValues(Seq(_))

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/UserSearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/UserSearchServiceSpec.scala
@@ -1,0 +1,30 @@
+package com.socrata.cetera.services
+
+import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+
+import com.socrata.cetera.search.UserClient
+import com.socrata.cetera.{TestESClient, TestESData}
+
+class UserSearchServiceSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
+  val client = new TestESClient(testSuiteName)
+  val userClient = new UserClient(client, testSuiteName)
+  val service = new UserSearchService(userClient)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    bootstrapData()
+  }
+
+  override protected def afterAll(): Unit = {
+    removeBootstrapData()
+    client.close()
+    super.afterAll()
+  }
+
+  test("search without authentication for any and all users yields results and timing") {
+    val (results, timings) = service.doSearch(Map.empty, None, None, None)
+
+    results.results.headOption should be('defined)
+    timings.searchMillis.headOption should be('defined)
+  }
+}

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/UserSearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/UserSearchServiceSpec.scala
@@ -1,30 +1,114 @@
 package com.socrata.cetera.services
 
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import com.rojoma.json.v3.interpolation._
+import com.rojoma.json.v3.io.CompactJsonWriter
+import com.socrata.http.server.responses._
+import org.mockserver.integration.ClientAndServer._
+import org.mockserver.model.HttpRequest._
+import org.mockserver.model.HttpResponse._
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, Matchers}
 
+import com.socrata.cetera._
 import com.socrata.cetera.search.UserClient
-import com.socrata.cetera.{TestESClient, TestESData}
 
-class UserSearchServiceSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterAll {
+class UserSearchServiceSpec extends FunSuiteLike with Matchers with TestESData
+  with BeforeAndAfterAll with BeforeAndAfterEach {
+
+  val httpClient = new TestHttpClient()
+  val coreTestPort = 8030
+  val mockServer = startClientAndServer(coreTestPort)
+  val coreClient = new TestCoreClient(httpClient, coreTestPort)
+
   val client = new TestESClient(testSuiteName)
   val userClient = new UserClient(client, testSuiteName)
-  val service = new UserSearchService(userClient)
+  val service = new UserSearchService(userClient, coreClient)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     bootstrapData()
   }
 
+  override def beforeEach(): Unit = {
+    mockServer.reset()
+  }
+
   override protected def afterAll(): Unit = {
     removeBootstrapData()
     client.close()
+    mockServer.stop(true)
+    httpClient.close()
     super.afterAll()
   }
 
-  test("search without authentication for any and all users yields results and timing") {
-    val (results, timings) = service.doSearch(Map.empty, None, None, None)
+  test("authenticate rejects anonymous requests") {
+    val (auth, _) = service.verifyUserAuthorization(None, None, None)
+    auth should be(false)
+  }
 
+  test("search without authentication is rejected") {
+    val (status, results, _, _) = service.doSearch(Map.empty, None, None, None)
+    status should be(Unauthorized)
+    results.results.headOption should be('empty)
+  }
+
+  test("search with authentication returns any and all users") {
+    val cookie = "Traditional = WASD"
+    val host = "Superior = ESDF"
+
+    val authedUserBody =
+      j"""{
+        "id" : "boo-bear",
+        "roleName" : "headBear",
+        "rights" : [ "steal_honey", "scare_tourists"],
+        "flags" : [ "admin" ]
+        }"""
+    val expectedRequest = request()
+      .withMethod("GET")
+      .withPath("/users.json")
+      .withHeader(HeaderXSocrataHostKey, host)
+    mockServer.when(
+      expectedRequest
+    ).respond(
+      response()
+        .withStatusCode(200)
+        .withHeader("Content-Type", "application/json; charset=utf-8")
+        .withBody(CompactJsonWriter.toString(authedUserBody))
+    )
+
+    val (status, results, _, _) = service.doSearch(Map.empty, Some(cookie), Some(host), None)
+
+    mockServer.verify(expectedRequest)
+    status should be(OK)
     results.results.headOption should be('defined)
-    timings.searchMillis.headOption should be('defined)
+  }
+
+  test("search with authentication but without authorization is rejected") {
+    val cookie = "Traditional = WASD"
+    val host = "Superior = ESDF"
+
+    val authedUserBody =
+      j"""{
+        "id" : "boo-bear",
+        "roleName" : "headBear",
+        "rights" : [ "steal_honey", "scare_tourists"]
+        }"""
+    val expectedRequest = request()
+      .withMethod("GET")
+      .withPath("/users.json")
+      .withHeader(HeaderXSocrataHostKey, host)
+    mockServer.when(
+      expectedRequest
+    ).respond(
+      response()
+        .withStatusCode(200)
+        .withHeader("Content-Type", "application/json; charset=utf-8")
+        .withBody(CompactJsonWriter.toString(authedUserBody))
+    )
+
+    val (status, results, _, _) = service.doSearch(Map.empty, Some(cookie), Some(host), None)
+
+    mockServer.verify(expectedRequest)
+    status should be(Unauthorized)
+    results.results.headOption should be('empty)
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,8 +9,7 @@ object CeteraBuild extends Build {
 
   lazy val commonSettings = Seq(
     scalaVersion := "2.11.7",
-    // keeping 2.10 around during transition, once we're happy with 2.11 in prod we can remove it.
-    crossScalaVersions := Seq("2.10.4", scalaVersion.value),
+    crossScalaVersions := Seq(scalaVersion.value),
 
     scalacOptions ++= Seq("-Yinline-warnings"),
 


### PR DESCRIPTION
**what it do**
* add another User type, backed by elasticsearch documents of type user
* search for users by screen name and email address
* requires authentication and admin or superadmin authorization

**dependencies forward and back**
* tour-bus mapping changes in https://github.com/socrata/tour-bus/pull/12
* rammy mapping changes in https://github.com/socrata/rammstein/pull/115
* frontend changes forthcoming

**notably missing from these legs**
* not replacing the core+metadb calls that return domain users with roles
* not replacing the bit that shows users with pending invitations not yet accepted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socrata/cetera/158)
<!-- Reviewable:end -->
