### PR TITLE
EN-6955 Ignore malformed ES docs instead of throwing

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DomainClient.scala
@@ -54,12 +54,12 @@ class DomainClient(esClient: ElasticSearchClient, coreClient: CoreClient, indexA
 
     val res = search.execute.actionGet
     val timing = res.getTookInMillis
-    val domains = res.getHits.hits.flatMap { h =>
-      JsonUtil.parseJson[Domain](h.sourceAsString) match {
-        case Right(domain) => Some(domain)
-        case Left(err) =>
-          logger.error(err.english)
-          throw new JsonDecodeException(err)
+
+    val domains = res.getHits.hits.flatMap { hit =>
+      try { Domain(hit.sourceAsString) }
+      catch { case e: Exception =>
+        logger.info(e.getMessage)
+        None
       }
     }.toSet
 
@@ -150,9 +150,15 @@ class DomainClient(esClient: ElasticSearchClient, coreClient: CoreClient, indexA
 
     val res = search.execute.actionGet
     val timing = res.getTookInMillis
-    val domains = res.getHits.hits.flatMap { h =>
-      Domain(h.getSourceAsString)
+
+    val domains = res.getHits.hits.flatMap { hit =>
+      try { Domain(hit.getSourceAsString) }
+      catch { case e: Exception =>
+        logger.info(e.getMessage)
+        None
+      }
     }.toSet
+
     (domains, timing)
   }
 

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Sorts.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Sorts.scala
@@ -8,15 +8,15 @@ import com.socrata.cetera.types._
 // TODO: Ultimately, these should accept Sortables rather than Strings
 object Sorts {
   val sortScoreDesc: SortBuilder = {
-    SortBuilders.scoreSort().order(SortOrder.DESC)
+    SortBuilders.scoreSort().order(SortOrder.DESC).missing("_last")
   }
 
   def sortFieldAsc(field: String): SortBuilder = {
-    SortBuilders.fieldSort(field).order(SortOrder.ASC)
+    SortBuilders.fieldSort(field).order(SortOrder.ASC).missing("_last")
   }
 
   def sortFieldDesc(field: String): SortBuilder = {
-    SortBuilders.fieldSort(field).order(SortOrder.DESC)
+    SortBuilders.fieldSort(field).order(SortOrder.DESC).missing("_last")
   }
 
   def buildAverageScoreSort(
@@ -28,6 +28,7 @@ object Sorts {
     SortBuilders
       .fieldSort(fieldName)
       .order(SortOrder.DESC)
+      .missing("_last")
       .sortMode("avg")
       .setNestedFilter(
         FilterBuilders.termsFilter(

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/UserClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/UserClient.scala
@@ -47,12 +47,12 @@ class UserClient(esClient: ElasticSearchClient, indexAliasName: String) extends 
 
     val res = req.execute.actionGet
     val timing = res.getTookInMillis
-    val users = res.getHits.hits.flatMap { h =>
-      JsonUtil.parseJson[EsUser](h.sourceAsString) match {
-        case Right(u) => Some(u)
-        case Left(err) =>
-          logger.error(err.english)
-          throw new JsonDecodeException(err)
+
+    val users = res.getHits.hits.flatMap { hit =>
+      try { EsUser(hit.sourceAsString) }
+      catch { case e: Exception =>
+        logger.info(e.getMessage)
+        None
       }
     }.toSet
 

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -707,7 +707,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
                             ]
                         }
                     },
-                    "order": "desc"
+                    "order": "desc",
+                    "missing": "_last"
                 }
             }
         ]

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
@@ -25,7 +25,8 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
       val field = "field.in.our.documents"
       val expectedAsString = s"""
         |"${field}"{
-        |  "order" : "asc"
+        |  "order" : "asc",
+        |  "missing" : "_last"
         |}""".stripMargin
 
       val actual = Sorts.sortFieldAsc(field)
@@ -39,7 +40,8 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
       val field = "another_field.another_field_total"
       val expectedAsString = s"""
         |"${field}"{
-        |  "order" : "desc"
+        |  "order" : "desc",
+        |  "missing" : "_last"
         |}""".stripMargin
 
       val actual = Sorts.sortFieldDesc(field)
@@ -58,6 +60,7 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
       val expectedAsString = s"""
          |"${fieldName}"{
          |  "order" : "desc",
+         |  "missing" : "_last",
          |  "mode" : "avg",
          |  "nested_filter" : {
          |    "terms" : {
@@ -120,6 +123,7 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
       val expectedAsString = s"""
         |"animl_annotations.categories.score"{
         |  "order" : "desc",
+        |  "missing" : "_last",
         |  "mode" : "avg",
         |  "nested_filter" : {
         |    "terms" : {
@@ -144,6 +148,7 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
       val expectedAsString = s"""
         |"animl_annotations.tags.score"{
         |  "order" : "desc",
+        |  "missing" : "_last",
         |  "mode" : "avg",
         |  "nested_filter" : {
         |    "terms" : {


### PR DESCRIPTION
* Affects Documents, Domains, and Users
* 4 hits.flatMap calls wrap their parsings with try/catch
* Missing required fields and corrupted fields cause docs to be skipped
* Docs with missing sort fields get pushed to the end of results (just in case)