### PR TITLE
EN-7340 Set user search limit to 200 instead of 1 million

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/search/UserClient.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/UserClient.scala
@@ -25,7 +25,7 @@ class UserClient(esClient: ElasticSearchClient, indexAliasName: String) extends 
   }
 
   // TODO: setup user search pagination
-  val maxLimit = 1000000
+  val maxLimit = 200 // Parity with Core for now
   def search(query: Option[String], limit: Int = maxLimit, offset: Int = 0): (Set[EsUser], Long) = {
     val baseQuery = query match {
       case None => QueryBuilders.matchAllQuery()

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -205,11 +205,13 @@ class SearchService(elasticSearchClient: BaseDocumentClient,
     (searchContextDomain, queryDomains, domainIdBoosts, domainSearchTime, setCookies)
   }
 
-  def doSearch(queryParameters: MultiQueryParams, // scalastyle:ignore parameter.number method.length
-               cookie: Option[String],
-               extendedHost: Option[String],
-               requestId: Option[String]
-              ): (SearchResults[SearchResult], InternalTimings, Seq[String]) = {
+  def doSearch( // scalastyle:ignore parameter.number method.length
+      queryParameters: MultiQueryParams,
+      cookie: Option[String],
+      extendedHost: Option[String],
+      requestId: Option[String])
+    : (SearchResults[SearchResult], InternalTimings, Seq[String]) = {
+
     val now = Timings.now()
 
     QueryParametersParser(queryParameters, extendedHost) match {

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/UserSearchService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/UserSearchService.scala
@@ -21,12 +21,15 @@ class UserSearchService(userClient: UserClient, coreClient: CoreClient, domainCl
   lazy val logger = LoggerFactory.getLogger(getClass)
   val verificationClient = new VerificationClient(coreClient)
 
+  // WARN: I do not used validated query parameters!
+  // See SearchService.scala for comparison
   def doSearch(
       queryParameters: MultiQueryParams,
       cookie: Option[String],
       extendedHost: Option[String],
       requestId: Option[String])
-  : (StatusResponse, SearchResults[DomainUser], InternalTimings, Seq[String]) = {
+    : (StatusResponse, SearchResults[DomainUser], InternalTimings, Seq[String]) = {
+
     val now = Timings.now()
 
     val (authorized, setCookies) =


### PR DESCRIPTION
* High limits can potentially OOM Cetera by instantiating too many objects
* Also reformatted SearchService#doSearch method signature for style consistency