### PR TITLE
EN-8074: Add ability to search users by role

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/services/UserSearchService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/UserSearchService.scala
@@ -37,10 +37,11 @@ class UserSearchService(userClient: UserClient, verificationClient: Verification
     val (status, results: SearchResults[DomainUser], timings) =
       if (authorizedUser.isDefined) {
         val query = queryParameters.getOrElse("q", Seq.empty).headOption
-        val (results: Seq[EsUser], userSearchTime) = userClient.search(query)
-
-        val domainCname = extendedHost.getOrElse("")  // authorization implies a domain was given in extendedHost
+        val role = queryParameters.getOrElse("role", Seq.empty).headOption
+        val domainCname = extendedHost.getOrElse("") // authorization implies a domain was given in extendedHost
         val (domain, domainSearchTime) = domainClient.find(domainCname)
+
+        val (results: Seq[EsUser], userSearchTime) = userClient.search(query, role, domain)
 
         val formattedResults = SearchResults[DomainUser](results.flatMap(u => DomainUser(domain, u)),
           results.size)

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -260,3 +260,15 @@ case object ScreenName extends UserFieldType with Rawable {
 case object Email extends UserFieldType with Rawable {
   val fieldName: String = "email"
 }
+
+case object Roles extends UserFieldType with Rawable {
+  val fieldName: String = "roles"
+
+  case object Role_Name extends NestedField {
+    protected lazy val path: String = Roles.fieldName
+  }
+
+  case object Domain_Id extends NestedField {
+    protected lazy val path: String = Roles.fieldName
+  }
+}

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/UserClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/UserClientSpec.scala
@@ -31,32 +31,77 @@ class UserClientSpec extends FunSuiteLike with Matchers with TestESData with Bef
   }
 
   test("search returns all by default") {
-    val (userRes, _) = userClient.search(None)
+    val (userRes, _) = userClient.search(None, None, None)
     userRes should contain theSameElementsAs(users)
   }
 
   test("search for user by exact name") {
-    val (userRes, _) = userClient.search(Some("death-the-kid"))
+    val (userRes, _) = userClient.search(Some("death-the-kid"), None, None)
     userRes.head should be(users(1))
   }
 
   test("search for user by partial name") {
-    val (userRes, _) = userClient.search(Some("kid"))
+    val (userRes, _) = userClient.search(Some("kid"), None, None)
     userRes.head should be(users(1))
   }
 
   test("search for user by exact email") {
-    val (userRes, _) = userClient.search(Some("death.kid@deathcity.com"))
+    val (userRes, _) = userClient.search(Some("death.kid@deathcity.com"), None, None)
     userRes.head should be(users(1))
   }
 
   test("search for user by email alias") {
-    val (userRes, _) = userClient.search(Some("death.kid"))
+    val (userRes, _) = userClient.search(Some("death.kid"), None, None)
     userRes.head should be(users(1))
   }
 
   test("search for user by email domain") {
-    val (userRes, _) = userClient.search(Some("deathcity.com"))
+    val (userRes, _) = userClient.search(Some("deathcity.com"), None, None)
     userRes should contain theSameElementsAs(List(users(1), users(2)))
+  }
+
+  test("search for users by non-existent role, get a None") {
+    val (userRes, _) = userClient.search(None, Some("muffin"), None)
+    userRes should be('empty)
+  }
+
+  test("search for users by role") {
+    val (userRes, _) = userClient.search(None, Some("headmaster"), None)
+    userRes.head should be(users(1))
+  }
+
+  test("search for users by non-existent domain, get a None") {
+    val domain = Option(domains(1))
+    val (userRes, _) = userClient.search(None, None, domain)
+    userRes should be('empty)
+  }
+
+  test("search for users by domain") {
+    val domain = Option(domains(0))
+    val (userRes, _) = userClient.search(None, None, domain)
+    userRes should contain theSameElementsAs(List(users(0), users(1), users(2)))
+  }
+
+  test("search for users by query and role") {
+    val (userRes, _) = userClient.search(Some("death-the-kid"), Some("headmaster"), None)
+    userRes.head should be(users(1))
+  }
+
+  test("search for users by query and domain") {
+    val domain = Option(domains(0))
+    val (userRes, _) = userClient.search(Some("death-the-kid"), None, domain)
+    userRes.head should be(users(1))
+  }
+
+  test("search for users by role and domain") {
+    val domain = Option(domains(0))
+    val (userRes, _) = userClient.search(None, Some("headmaster"), domain)
+    userRes.head should be(users(1))
+  }
+
+  test("search for users by query, role, and domain") {
+    val domain = Option(domains(0))
+    val (userRes, _) = userClient.search(Some("death-the-kid"), Some("headmaster"), domain)
+    userRes.head should be(users(1))
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/UserSearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/UserSearchServiceSpec.scala
@@ -168,4 +168,29 @@ class UserSearchServiceSpec extends FunSuiteLike with Matchers with TestESData
     val expectedFirstUser = DomainUser(context, users(1)).get
     results.results.head should be(expectedFirstUser)
   }
+
+  test("searching by email and role should produce most relevant result first") {
+    val expectedRequest = request()
+      .withMethod("GET")
+      .withPath("/users.json")
+      .withHeader(HeaderXSocrataHostKey, host)
+    mockServer.when(
+      expectedRequest
+    ).respond(
+      response()
+        .withStatusCode(200)
+        .withHeader("Content-Type", "application/json; charset=utf-8")
+        .withBody(CompactJsonWriter.toString(adminUserBody))
+    )
+
+    val params = Map(Params.querySimple -> "dark.star@deathcity.com", "role" -> "assasin").mapValues(Seq(_))
+    val (status, results, _, _) = service.doSearch(params, Some(cookie), Some(host), None)
+    mockServer.verify(expectedRequest)
+    status should be(OK)
+
+    results.results.headOption should be('defined)
+    val expectedFirstUser = DomainUser(context, users(2)).get
+    results.results.head should be(expectedFirstUser)
+
+  }
 }


### PR DESCRIPTION
**What it does:**
- Listens for the new "role" param in the /whitepages endpoint
- Builds up a query and filters based on role, query, and/or domain, and correctly matches all where any of those parameters are not specified

**How it's tested:**
- sbt test / clean assembly / run
- wrote additional tests

paired-with: ayn.leslie@socrata.com