### PR TITLE
EN-9093: Ensure log message has requestId

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/SearchServer.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/SearchServer.scala
@@ -4,12 +4,12 @@ import java.util.concurrent.{ExecutorService, Executors}
 
 import com.rojoma.simplearm.v2._
 import com.socrata.http.client.{HttpClientHttpClient, InetLivenessChecker}
-import com.socrata.http.server.SocrataServerJetty
+import com.socrata.http.server.{HttpRequest, HttpResponse, SocrataServerJetty}
 import com.socrata.thirdparty.typesafeconfig.Propertizer
 import com.typesafe.config.ConfigFactory
 import org.apache.log4j.PropertyConfigurator
 import org.elasticsearch.client.transport.TransportClient
-import org.slf4j.LoggerFactory
+import org.slf4j.{LoggerFactory, MDC}
 
 import com.socrata.cetera.auth.{CoreClient, VerificationClient}
 import com.socrata.cetera.config.CeteraConfig
@@ -109,7 +109,10 @@ object SearchServer extends App {
     )
 
     logger.info("Initializing handler")
-    val handler = router.route _
+    val handler: HttpRequest => HttpResponse = (req: HttpRequest) => {
+      MDC.put("requestId", req.requestId)
+      router.route(req)
+    }
 
     logger.info("Initializing server")
     val server = new SocrataServerJetty(


### PR DESCRIPTION
**What it do**
We had a spot in the logging config to display `requestId` but it was never actually being populated when a request came in.

**How was it tested?**
`sbt test` passes locally, ran a couple queries locally and watched the logs have different ids (second pair of []).
 
```
[qtp1363431563-69] [8czfvjkslnywqz17cuy5hd93z] DEBUG SearchService 2016-08-17 16:43:27,675 received http request:
GET /catalog/v1?categories=Health,Finance
User-Agent: curl/7.49.0
Accept: */*
Host: localhost:5704


[qtp1363431563-69] [8czfvjkslnywqz17cuy5hd93z] INFO DomainClient 2016-08-17 16:43:28,397 Elasticsearch request body: { "size" : 42000, "query" : { "filtered" : { "query" : { "match_all" : { } }, "filter" : { "not" : { "filter" : { "term" : { "is_customer_domain" : false } } } } } } }
[qtp1363431563-69] [8czfvjkslnywqz17cuy5hd93z] INFO SearchService 2016-08-17 16:43:29,017 Elasticsearch request body: { "from" : 0, "size" : 100, "query" : { "function_score" : { "query" : { "filtered" : { "query" : { "bool" : { "must" : [ { "bool" : { "must" : { "match_all" : { } } } }, { "nested" : { "query" : { "bool" : { "should" : { "match" : { "animl_annotations.categories.name" : { "query" : "Health,Finance", "type" : "phrase" } } }, "minimum_should_match" : "1" } }, "path" : "animl_annotations.categories" } } ] } }, "filter" : { "bool" : { "must" : [ { "bool" : { "must" : [ { "not" : { "filter" : { "term" : { "is_public" : false } } } }, { "not" : { "filter" : { "term" : { "is_published" : false } } } }, { "bool" : { "should" : [ { "term" : { "is_default_view" : true } }, { "term" : { "is_moderation_approved" : true } }, { "bool" : { "must" : [ { "terms" : { "socrata_id.domain_id" : [ 88, 42, 37, 25, 52, 20, 29, 106, 61, 74, 6, 85, 102, 28, 9, 77, 13, 41, 73, 17, 22, 44, 71, 12, 54, 49, 81, 76, 112, 48, 63, 67, 43, 99, 87, 8, 75, 82, 51, 19, 4, 79, 83 ] } }, { "not" : { "filter" : { "terms" : { "datatype" : [ "datalens", "datalens_chart", "datalens_map" ] } } } } ] } } ] } }, { "bool" : { "must" : { "bool" : { "should" : [ { "terms" : { "socrata_id.domain_id" : [ 88, 42, 37, 25, 52, 20, 29, 106, 61, 74, 6, 85, 102, 28, 9, 77, 13, 41, 73, 17, 22, 44, 71, 54, 49, 81, 76, 112, 48, 63, 67, 43, 99, 87, 8, 75, 82, 51, 19, 4, 79, 83 ] } }, { "term" : { "is_approved_by_parent_domain" : true } } ] } } } } ] } }, { "terms" : { "socrata_id.domain_id" : [ 88, 42, 37, 25, 52, 20, 29, 106, 84, 61, 89, 74, 6, 85, 102, 28, 9, 77, 13, 41, 73, 17, 22, 44, 71, 12, 54, 49, 86, 81, 76, 112, 48, 63, 67, 43, 99, 87, 8, 75, 82, 51, 19, 4, 79, 83 ] } } ] } } } }, "functions" : [ { "script_score" : { "script" : "1 + doc[\"page_views.page_views_total_log\"].value", "lang" : "expression" } }, { "script_score" : { "script" : "_score", "lang" : "expression" } } ], "score_mode" : "multiply", "boost_mode" : "replace" } }, "sort" : [ { "animl_annotations.categories.score" : { "order" : "desc", "missing" : "_last", "mode" : "avg", "nested_filter" : { "terms" : { "animl_annotations.categories.name.raw" : [ "Health,Finance" ] } } } } ] }
[qtp1363431563-69] [8czfvjkslnywqz17cuy5hd93z] INFO SearchService 2016-08-17 16:43:29,292 [GET] -- /catalog/v1 -- categories=Health,Finance -- requested by -- 0:0:0:0:0:0:0:1 -- extended host = None -- request id = None -- TIMINGS ## ESTime : List(23, 116) ## ServiceTime : 1549
[qtp1363431563-69] [8czfvjkslnywqz17cuy5hd93z] DEBUG Http$ 2016-08-17 16:43:29,400 sending http response with (partial) headers:
HTTP 200
Access-Control-Allow-Origin: *

[qtp1363431563-70] [bu2p9a54jq42k9tly0pusiqyh] DEBUG SearchService 2016-08-17 16:43:38,328 received http request:
GET /catalog/v1?categories=Health,Finance
User-Agent: curl/7.49.0
Accept: */*
Host: localhost:5704


[qtp1363431563-70] [bu2p9a54jq42k9tly0pusiqyh] INFO DomainClient 2016-08-17 16:43:38,329 Elasticsearch request body: { "size" : 42000, "query" : { "filtered" : { "query" : { "match_all" : { } }, "filter" : { "not" : { "filter" : { "term" : { "is_customer_domain" : false } } } } } } }
[qtp1363431563-70] [bu2p9a54jq42k9tly0pusiqyh] INFO SearchService 2016-08-17 16:43:38,482 Elasticsearch request body: { "from" : 0, "size" : 100, "query" : { "function_score" : { "query" : { "filtered" : { "query" : { "bool" : { "must" : [ { "bool" : { "must" : { "match_all" : { } } } }, { "nested" : { "query" : { "bool" : { "should" : { "match" : { "animl_annotations.categories.name" : { "query" : "Health,Finance", "type" : "phrase" } } }, "minimum_should_match" : "1" } }, "path" : "animl_annotations.categories" } } ] } }, "filter" : { "bool" : { "must" : [ { "bool" : { "must" : [ { "not" : { "filter" : { "term" : { "is_public" : false } } } }, { "not" : { "filter" : { "term" : { "is_published" : false } } } }, { "bool" : { "should" : [ { "term" : { "is_default_view" : true } }, { "term" : { "is_moderation_approved" : true } }, { "bool" : { "must" : [ { "terms" : { "socrata_id.domain_id" : [ 88, 42, 37, 25, 52, 20, 29, 106, 61, 74, 6, 85, 102, 28, 9, 77, 13, 41, 73, 17, 22, 44, 71, 12, 54, 49, 81, 76, 112, 48, 63, 67, 43, 99, 87, 8, 75, 82, 51, 19, 4, 79, 83 ] } }, { "not" : { "filter" : { "terms" : { "datatype" : [ "datalens", "datalens_chart", "datalens_map" ] } } } } ] } } ] } }, { "bool" : { "must" : { "bool" : { "should" : [ { "terms" : { "socrata_id.domain_id" : [ 88, 42, 37, 25, 52, 20, 29, 106, 61, 74, 6, 85, 102, 28, 9, 77, 13, 41, 73, 17, 22, 44, 71, 54, 49, 81, 76, 112, 48, 63, 67, 43, 99, 87, 8, 75, 82, 51, 19, 4, 79, 83 ] } }, { "term" : { "is_approved_by_parent_domain" : true } } ] } } } } ] } }, { "terms" : { "socrata_id.domain_id" : [ 88, 42, 37, 25, 52, 20, 29, 106, 84, 61, 89, 74, 6, 85, 102, 28, 9, 77, 13, 41, 73, 17, 22, 44, 71, 12, 54, 49, 86, 81, 76, 112, 48, 63, 67, 43, 99, 87, 8, 75, 82, 51, 19, 4, 79, 83 ] } } ] } } } }, "functions" : [ { "script_score" : { "script" : "1 + doc[\"page_views.page_views_total_log\"].value", "lang" : "expression" } }, { "script_score" : { "script" : "_score", "lang" : "expression" } } ], "score_mode" : "multiply", "boost_mode" : "replace" } }, "sort" : [ { "animl_annotations.categories.score" : { "order" : "desc", "missing" : "_last", "mode" : "avg", "nested_filter" : { "terms" : { "animl_annotations.categories.name.raw" : [ "Health,Finance" ] } } } } ] }
[qtp1363431563-70] [bu2p9a54jq42k9tly0pusiqyh] INFO SearchService 2016-08-17 16:43:38,604 [GET] -- /catalog/v1 -- categories=Health,Finance -- requested by -- 0:0:0:0:0:0:0:1 -- extended host = None -- request id = None -- TIMINGS ## ESTime : List(6, 49) ## ServiceTime : 275
[qtp1363431563-70] [bu2p9a54jq42k9tly0pusiqyh] DEBUG Http$ 2016-08-17 16:43:38,605 sending http response with (partial) headers:
HTTP 200
Access-Control-Allow-Origin: *

```

