### PR TITLE
EN-9147: Unmigrated NBE datasets filter

### DIFF
--- a/cetera-http/src/main/resources/mapping_document.json
+++ b/cetera-http/src/main/resources/mapping_document.json
@@ -172,7 +172,9 @@
       "properties": {
         "dataset_id": { "type": "string", "index": "not_analyzed" },
         "parent_dataset_id": { "type": "string", "index": "not_analyzed" },
-        "domain_id": { "type": "long" }
+        "domain_id": { "type": "long" },
+        "nbe_id": { "type": "string", "index": "not_analyzed" },
+        "obe_id": { "type": "string", "index": "not_analyzed" }
       }
     },
     "update_freq": { "type": "float" },

--- a/cetera-http/src/main/resources/mapping_domain.json
+++ b/cetera-http/src/main/resources/mapping_domain.json
@@ -17,6 +17,7 @@
     "is_customer_domain": { "type": "boolean" },
     "moderation_enabled": { "type": "boolean" },
     "routing_approval_enabled": { "type": "boolean" },
+    "unmigrated_nbe_enabled": { "type": "boolean" },
     "locked_down": { "type": "boolean" },
     "api_locked_down": { "type": "boolean" },
     "organization": {

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -153,11 +153,11 @@ object DocumentFilters {
     */
   def unmigratedNbeFilter(enabledIds: Set[Int]): FilterBuilder = {
     val parentDomainAllowsUnmigrated =
-      Some(enabledIds).filter(_.nonEmpty).map(eids => domainIdsFilter(eids))
+      Some(enabledIds).filter(_.nonEmpty).map(domainIdsFilter(_))
 
     val filter = boolFilter()
     filter.should(existsFilter(SocrataIdObeIdFieldType.fieldName))
-    parentDomainAllowsUnmigrated.foreach { f => filter.should(f)}
+    parentDomainAllowsUnmigrated.foreach(filter.should)
 
     filter
   }

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/Domain.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/Domain.scala
@@ -14,7 +14,8 @@ case class Domain(domainId: Int,
                   moderationEnabled: Boolean,
                   routingApprovalEnabled: Boolean,
                   lockedDown: Boolean,
-                  apiLockedDown: Boolean) {
+                  apiLockedDown: Boolean,
+                  unmigratedNbeEnabled: Boolean) {
 
   def isLocked: Boolean = lockedDown || apiLockedDown
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/DomainSet.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/DomainSet.scala
@@ -43,4 +43,5 @@ case class DomainSet(
   val allIds = domains.map(_.domainId)
   val (moderationEnabledIds, moderationDisabledIds) = partitionIds(_.moderationEnabled)
   val (_, raDisabledIds) = partitionIds(_.routingApprovalEnabled)
+  val (unmigratedNbeEnabledIds, _) = partitionIds(_.unmigratedNbeEnabled)
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/DomainSet.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/DomainSet.scala
@@ -29,9 +29,18 @@ case class DomainSet(
     }
   }
 
+  /**
+    * @param predicate to determine which partition a Domain should go into
+    * @return A tuple where the first element is all the ids of the domains that the predicate was
+    *         true for and the second is all the ids of the domains that the predicate is false for
+    */
+  private def partitionIds(predicate: Domain => Boolean): (Set[Int], Set[Int]) = {
+    val (trueDomains, falseDomains) = domains.partition(predicate)
+    (trueDomains.map(_.domainId), falseDomains.map(_.domainId))
+  }
+
   val contextIsModerated = searchContext.exists(_.moderationEnabled)
   val allIds = domains.map(_.domainId)
-  val moderationEnabledIds = domains.collect { case d: Domain if d.moderationEnabled => d.domainId }
-  val moderationDisabledIds = domains.collect { case d: Domain if !d.moderationEnabled => d.domainId }
-  val raDisabledIds = domains.collect { case d: Domain if !d.routingApprovalEnabled => d.domainId }
+  val (moderationEnabledIds, moderationDisabledIds) = partitionIds(_.moderationEnabled)
+  val (_, raDisabledIds) = partitionIds(_.routingApprovalEnabled)
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -154,6 +154,14 @@ case object SocrataIdDomainIdFieldType extends DocumentFieldType {
   val fieldName: String = "socrata_id.domain_id"
 }
 
+case object SocrataIdObeIdFieldType extends DocumentFieldType {
+  val fieldName: String = "socrata_id.obe_id"
+}
+
+case object SocrataIdNbeFieldType extends DocumentFieldType {
+  val fieldName: String = "socrata_id.nbe_id"
+}
+
 case object ParentDatasetIdFieldType extends DocumentFieldType {
   val fieldName: String = "socrata_id.parent_dataset_id"
 }

--- a/cetera-http/src/test/resources/domains.tsv
+++ b/cetera-http/src/test/resources/domains.tsv
@@ -1,10 +1,10 @@
-id	cname	siteTitle	Organization	isCustomerDomain	isDomainModerated	hasRoutingApproval	lockedDown	apiLockedDown
-0	petercetera.net	Temporary URI	org	true	false	false	false	false
-1	opendata-demo.socrata.com	And other things	org	false	true	false	false	false
-2	blue.org	Fame and Fortune	org	true	false	true	false	false
-3	annabelle.island.net	Socrata Demo	org	true	true	true	false	false
-4	dylan.demo.socrata.com	Skid Row	Hair Metal Bands	true	false	true	false	false
-5	dylan2.demo.socrata.com	Mötley Crüe	Hair Metal Bands	false	false	false	false	false
-6	locked.demo.com	Locked Down	org	false	true	true	true	false
-7	api.locked.demo.com	Api Locked Down	org	true	true	false	false	true
-8	double.locked.demo.com	Doubly Locked Down	org	true	true	true	true	true
+id	cname	siteTitle	Organization	isCustomerDomain	isDomainModerated	hasRoutingApproval	lockedDown	apiLockedDown unmigratedNbeEnabled
+0	petercetera.net	Temporary URI	org	true	false	false	false	false	false
+1	opendata-demo.socrata.com	And other things	org	false	true	false	false	false	false
+2	blue.org	Fame and Fortune	org	true	false	true	false	false	false
+3	annabelle.island.net	Socrata Demo	org	true	true	true	false	false	true
+4	dylan.demo.socrata.com	Skid Row	Hair Metal Bands	true	false	true	false	false	true
+5	dylan2.demo.socrata.com	Mötley Crüe	Hair Metal Bands	false	false	false	false	false	true
+6	locked.demo.com	Locked Down	org	false	true	true	true	false	false
+7	api.locked.demo.com	Api Locked Down	org	true	true	false	false	true	true
+8	double.locked.demo.com	Doubly Locked Down	org	true	true	true	true	true	true

--- a/cetera-http/src/test/resources/drewRaw.json
+++ b/cetera-http/src/test/resources/drewRaw.json
@@ -10,6 +10,8 @@
   "socrata_id": {
     "parent_dataset_id": "7v22-4z3a",
     "dataset_id": "94sr-dmsy",
+    "nbe_id": "94sr-dmsy",
+    "obe_id": "afha-1234",
     "domain_id": 283
   },
   "indexed_at": "2016-06-03T19:13:22.238Z",

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
@@ -56,7 +56,9 @@ trait TestESData {
       | "socrata_id": {
       |   "dataset_id": %s,
       |   "parent_dataset_id": %s,
-      |   "domain_id": %s
+      |   "domain_id": %s,
+      |   "nbe_id": %s,
+      |   "obe_id": %s
       | },
       | "resource": {
       |   "description": %s,
@@ -172,11 +174,15 @@ trait TestESData {
                          ownerScreenName: String,
                          sharedTo: Seq[String],
                          attribution: Option[String],
-                         previewImageId: Option[String]): String = {
+                         previewImageId: Option[String],
+                         socrataIdNbeId: Option[String],
+                         socrataIdObeId: Option[String]): String = {
     val doc = esDocTemplate.format(
       quoteQualify(socrataIdDatasetId),
       quoteQualify(parentDatasetId),
       domainId.toString,
+      quoteQualify(socrataIdNbeId),
+      quoteQualify(socrataIdObeId),
       quoteQualify(resourceDescription),
       quoteQualify(resourceNbeFxf),
       quoteQualify(parentDatasetId),
@@ -258,7 +264,9 @@ trait TestESData {
       ownerScreenNames(i % ownerScreenNames.length),
       sharedTos,
       attributions(i % attributions.length),
-      None)
+      None,
+      socrataIdNbeId(i % attributions.length),
+      socrataIdObeId(i % attributions.length))
   }
 
   val domainsWithData = domains.slice(0,4).map(d => d.domainCname)
@@ -301,6 +309,8 @@ trait TestESData {
   val ownerScreenNames = Seq("Robin Hood", "Little John")
   val sharedTos = Seq.empty
   val attributions = Seq[Option[String]](None)
+  val socrataIdNbeId = Seq("abcd-efgh", "1234-5678", "adsf-adas", "zyxw-vuts").map(Some(_))
+  val socrataIdObeId = Seq("hgfe-dcba", "8765-4321", "sada-fsda", "stuv-wxyz").map(Some(_))
 
   def bootstrapData(): Unit = {
     ElasticsearchBootstrap.ensureIndex(client, "yyyyMMddHHmm", testSuiteName)
@@ -341,7 +351,8 @@ trait TestESData {
         "", "", Seq.empty, Seq.empty, Seq.empty,
         Map.empty,
         isPublic = true, isPublished = true, isDefaultView = false, Some(true), Seq(0), isApprovedByParentDomain = true,
-        "42", "Fun", Seq.empty, 0L, "robin-hood", "Robin Hood", Seq.empty, None, None
+        "42", "Fun", Seq.empty, 0L, "robin-hood", "Robin Hood", Seq.empty, None, None,
+        Some("zeta-0001"), Some("data-0001")
       )),
       (3, buildEsDoc(
         "zeta-0002", None, 3,
@@ -351,7 +362,8 @@ trait TestESData {
         "", "", Seq.empty, Seq.empty, Seq.empty,
         Map.empty,
         isPublic = true, isPublished = true, isDefaultView = false, Some(true), Seq(2,3), isApprovedByParentDomain = true,
-        "42", "Fun", Seq.empty, 0L, "lil-john", "Little John", Seq.empty, None, None
+        "42", "Fun", Seq.empty, 0L, "lil-john", "Little John", Seq.empty, None, None,
+        Some("zeta-0002"), Some("data-0002")
       )),
       (0, buildEsDoc(
         "zeta-0003", None, 0,
@@ -361,7 +373,8 @@ trait TestESData {
         "", "", Seq.empty, Seq.empty, Seq.empty,
         Map.empty,
         isPublic = false, isPublished = true, isDefaultView = true, Some(true), Seq(0, 1, 2,3), isApprovedByParentDomain = true,
-        "42", "Private", Seq.empty, 0L, "robin-hood", "Robin Hood", Seq("Little John"), None, None
+        "42", "Private", Seq.empty, 0L, "robin-hood", "Robin Hood", Seq("Little John"), None, None,
+        Some("zeta-0003"), Some("data-0003")
       )),
       (0, buildEsDoc(
         "zeta-0004", None, 0,
@@ -371,7 +384,8 @@ trait TestESData {
         "", "", Seq.empty, Seq.empty, Seq.empty,
         Map.empty,
         isPublic = true, isPublished = true, isDefaultView = false, isModerationApproved = None, Seq(0, 1, 2,3), isApprovedByParentDomain = true,
-        "42", "Standalone", Seq.empty, 0L, "lil-john", "Little John", Seq.empty, None, None
+        "42", "Standalone", Seq.empty, 0L, "lil-john", "Little John", Seq.empty, None, None,
+        Some("zeta-0004"), Some("data-0004")
       )),
       (3, buildEsDoc(
         "zeta-0005", None, 3,
@@ -380,7 +394,8 @@ trait TestESData {
         TypeDatasets.singular, viewtype = "", 0F,
         "", "", Seq.empty, Seq.empty, Seq.empty, Map.empty,
         isPublic = true, isPublished = true, isDefaultView = true, Some(true), Seq(3), isApprovedByParentDomain = true,
-        "42", "Fun", Seq.empty, 0L, "john-clan", "John McClane", Seq.empty, None, None
+        "42", "Fun", Seq.empty, 0L, "john-clan", "John McClane", Seq.empty, None, None,
+        Some("zeta-0005"), Some("data-0005")
       )),
       (0, buildEsDoc(
         "zeta-0006", None, 0,
@@ -390,7 +405,8 @@ trait TestESData {
         "", "", Seq.empty, Seq.empty, Seq.empty,
         Map.empty,
         isPublic = true, isPublished = false, isDefaultView = true, Some(true), Seq(0, 1, 2,3), isApprovedByParentDomain = true,
-        "42", "Unpublished", Seq.empty, 0L, "robin-hood", "Robin Hood", Seq("Little John"), None, None
+        "42", "Unpublished", Seq.empty, 0L, "robin-hood", "Robin Hood", Seq("Little John"), None, None,
+        Some("zeta-0006"), Some("data-0006")
        )),
       (0, buildEsDoc(
         "zeta-0007", None, 0,
@@ -401,7 +417,8 @@ trait TestESData {
         Map.empty,
         isPublic = true, isPublished = true, isDefaultView = true, Some(true), Seq(0, 1, 2, 3), isApprovedByParentDomain = true,
         "42", "Fun", Seq.empty, 0L, "lil-john", "Little John", sharedTo = Seq("King Richard"),
-        attribution = Some("The Merry Men"), previewImageId = Some("123456789")
+        attribution = Some("The Merry Men"), previewImageId = Some("123456789"),
+        Some("zeta-0007"), Some("data-0007")
       )),
       (8, buildEsDoc(
         "zeta-0008", None, 8,
@@ -411,7 +428,7 @@ trait TestESData {
         Map.empty,
         isPublic = true, isPublished = true, isDefaultView = true, Some(true), Seq(8), isApprovedByParentDomain = true,
         "42", "Fun", List("fake", "king"), 0L, "prince-john", "Prince John", Seq.empty,
-        attribution = None, previewImageId = None
+        attribution = None, previewImageId = None, Some("zeta-0008"), Some("data-0008")
       )),
       (9, buildEsDoc(
         "zeta-0009", None, 3,
@@ -421,7 +438,7 @@ trait TestESData {
         Map.empty,
         isPublic = false, isPublished = true, isDefaultView = false, Some(true), Seq(3), isApprovedByParentDomain = true,
         "42", "Fun", List("fake", "king"), 0L, "prince-john", "Prince John", Seq.empty,
-        attribution = None, previewImageId = None
+        attribution = None, previewImageId = None, Some("zeta-009"), Some("data-0009")
       ))
     ).foreach { case (domain, doc) =>
       client.client.prepareIndex(testSuiteName, esDocumentType)

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
@@ -27,7 +27,8 @@ trait TestESData {
         moderationEnabled = tsvLine(5).toBoolean,
         routingApprovalEnabled = tsvLine(6).toBoolean,
         lockedDown = tsvLine(7).toBoolean,
-        apiLockedDown = tsvLine(8).toBoolean
+        apiLockedDown = tsvLine(8).toBoolean,
+        unmigratedNbeEnabled = tsvLine(9).toBoolean
       )
     }.toSeq
   }

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
@@ -385,7 +385,7 @@ trait TestESData {
         Map.empty,
         isPublic = true, isPublished = true, isDefaultView = false, isModerationApproved = None, Seq(0, 1, 2,3), isApprovedByParentDomain = true,
         "42", "Standalone", Seq.empty, 0L, "lil-john", "Little John", Seq.empty, None, None,
-        Some("zeta-0004"), Some("data-0004")
+        None, Some("zeta-0004")
       )),
       (3, buildEsDoc(
         "zeta-0005", None, 3,
@@ -395,7 +395,7 @@ trait TestESData {
         "", "", Seq.empty, Seq.empty, Seq.empty, Map.empty,
         isPublic = true, isPublished = true, isDefaultView = true, Some(true), Seq(3), isApprovedByParentDomain = true,
         "42", "Fun", Seq.empty, 0L, "john-clan", "John McClane", Seq.empty, None, None,
-        Some("zeta-0005"), Some("data-0005")
+        None, Some("zeta-0005")
       )),
       (0, buildEsDoc(
         "zeta-0006", None, 0,
@@ -428,7 +428,8 @@ trait TestESData {
         Map.empty,
         isPublic = true, isPublished = true, isDefaultView = true, Some(true), Seq(8), isApprovedByParentDomain = true,
         "42", "Fun", List("fake", "king"), 0L, "prince-john", "Prince John", Seq.empty,
-        attribution = None, previewImageId = None, Some("zeta-0008"), Some("data-0008")
+        attribution = None, previewImageId = None,
+        Some("zeta-0008"), None
       )),
       (9, buildEsDoc(
         "zeta-0009", None, 3,
@@ -438,7 +439,21 @@ trait TestESData {
         Map.empty,
         isPublic = false, isPublished = true, isDefaultView = false, Some(true), Seq(3), isApprovedByParentDomain = true,
         "42", "Fun", List("fake", "king"), 0L, "prince-john", "Prince John", Seq.empty,
-        attribution = None, previewImageId = None, Some("zeta-009"), Some("data-0009")
+        attribution = None, previewImageId = None,
+        Some("zeta-009"), Some("data-0009")
+      )),
+      // This document is a essentially a copy of "zeta-0008" but should never show up as a result because
+      // it is a NBE only dataset on a domain that does not display NBE only datasets
+      (10, buildEsDoc(
+        "zeta-0010", None, 0,
+        "a nbe only dataset",  "zeta-0009", DateTime.now.toString, DateTime.now.toString,
+        "zeta-0010", Seq.empty, "", None, Map.empty, Map.empty, TypeDatasets.singular, viewtype = "", 0F,
+        "", "", Seq.empty, Seq.empty, Seq.empty,
+        Map.empty,
+        isPublic = true, isPublished = true, isDefaultView = true, Some(true), Seq(0), isApprovedByParentDomain = true,
+        "42", "Fun", List("fake", "king"), 0L, "barack-obama", "Barack Obama", Seq.empty,
+        attribution = None, previewImageId = None,
+        Some("zeta-0010"), None
       ))
     ).foreach { case (domain, doc) =>
       client.client.prepareIndex(testSuiteName, esDocumentType)

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESDataSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESDataSpec.scala
@@ -67,7 +67,7 @@ class TestESDataSpec extends FunSuiteLike with Matchers with TestESData with Bef
 
   test("test documents are bootstrapped") {
     val res = client.client.prepareSearch().setTypes(esDocumentType).execute.actionGet
-    val numDocs = Datatypes.materialized.length + 9
+    val numDocs = Datatypes.materialized.length + 10
     res.getHits.getTotalHits should be(numDocs)
   }
 

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -119,6 +119,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   val raApprovedFilter = j"""{"term": {"is_approved_by_parent_domain": true}}"""
   val moderationFilter = j"""{"bool": { "should": [$defaultViewFilter, $modApprovedFilter]}}"""
   val routingApprovalFilter = j"""{"bool": {"must": {"bool": {"should": $raApprovedFilter}}}}"""
+  val unmigratedNbeFilter = j"""{"bool": {"should": {"exists": {"field": "socrata_id.obe_id"}}}}"""
 
   val defaultFilter = j"""{
     "bool": {
@@ -127,7 +128,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         ${publicFilter},
         ${publishedFilter},
         ${moderationFilter},
-        ${routingApprovalFilter}]}
+        ${routingApprovalFilter},
+        ${unmigratedNbeFilter}]}
   }"""
 
   val defaultFilterPlusDomainIds = j"""{
@@ -137,7 +139,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         ${publishedFilter},
         ${domainsFilter},
         ${moderationFilter},
-        ${routingApprovalFilter}]}
+        ${routingApprovalFilter},
+        ${unmigratedNbeFilter}]}
   }"""
 
   val datatypeDatasetsFilter = j"""{
@@ -215,7 +218,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
               ${publicFilter},
               ${publishedFilter},
               ${moderationFilter},
-              ${routingApprovalFilter}
+              ${routingApprovalFilter},
+              ${unmigratedNbeFilter}
             ]
           }
         },
@@ -308,7 +312,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
               {"bool" :{"must" :{"bool" :{"should" :[
                 $domain42Filter,
                 $raApprovedFilter
-              ]}}}}
+              ]}}}},
+              {"bool": {"should": {"exists": {"field": "socrata_id.obe_id"}}}}
             ]}},
             $domain42Filter
           ]}},

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -285,7 +285,8 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         moderationEnabled = false,
         routingApprovalEnabled = false,
         lockedDown = false,
-        apiLockedDown = false)
+        apiLockedDown = false,
+        unmigratedNbeEnabled = false)
 
       val domain42Filter =  j"""{"terms": {"socrata_id.domain_id": [42]}}"""
       val datalensSnowflakeFilter = j"""{"not" :{"filter" :{"terms" :{"datatype" :["datalens","datalens_chart","datalens_map"]}}}}"""

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/FiltersSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/FiltersSpec.scala
@@ -213,6 +213,30 @@ class FiltersSpec extends WordSpec with ShouldMatchers {
     }
   }
 
+  "DocumentFilters: unmigratedNbeFilter" should {
+    "return the expected filter when given no domain ids" in {
+      val filter = DocumentFilters.unmigratedNbeFilter(Set())
+      val actual = JsonReader.fromString(filter.toString)
+      val expected =
+        j"""{"bool": {"should":
+              {"exists": {"field": "socrata_id.obe_id" }}
+            }}"""
+      actual should be(expected)
+    }
+
+
+    "return the expected filter when given domains with unmigrated_nbe_enabled turned on" in {
+      val filter = DocumentFilters.unmigratedNbeFilter(Set(1, 2, 3))
+      val actual = JsonReader.fromString(filter.toString)
+      val expected =
+        j"""{"bool": {"should": [
+              {"exists": {"field": "socrata_id.obe_id" }},
+              {"terms": {"socrata_id.domain_id": [1, 2, 3] }}
+            ]}}"""
+      actual should be(expected)
+    }
+  }
+
   "DocumentFilters: publicFilter" should {
     "return the expected filter" in {
       val filter = DocumentFilters.publicFilter(false)

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/SortsSpec.scala
@@ -102,7 +102,8 @@ class SortsSpec extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
         moderationEnabled = false,
         routingApprovalEnabled = true,
         lockedDown = false,
-        apiLockedDown = false
+        apiLockedDown = false,
+        unmigratedNbeEnabled = false
       )
 
       val searchParams = SearchParamSet(searchQuery = SimpleQuery("soup salad sandwich"))

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -51,7 +51,7 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
   val emptySearchHitMap = Map[String,SearchHitField]().asJava
 
   val domains = Set(
-    Domain(0, "socrata.com", None, None, true, false, false, false, false, false),
+    Domain(0, "socrata.com", None, None, true, false, false, false, false, true),
     Domain(1, "first-socrata.com", None, None, true, false, false, false, false, false),
     Domain(2, "second-socrata.com", None, None, true, false, false, false ,false, false))
   val domainSet = DomainSet(domains = domains)

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -51,9 +51,9 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
   val emptySearchHitMap = Map[String,SearchHitField]().asJava
 
   val domains = Set(
-    Domain(0, "socrata.com", None, None, true, false, false, false, false),
-    Domain(1, "first-socrata.com", None, None, true, false, false, false, false),
-    Domain(2, "second-socrata.com", None, None, true, false, false, false ,false))
+    Domain(0, "socrata.com", None, None, true, false, false, false, false, false),
+    Domain(1, "first-socrata.com", None, None, true, false, false, false, false, false),
+    Domain(2, "second-socrata.com", None, None, true, false, false, false ,false, false))
   val domainSet = DomainSet(domains = domains)
 
   val searchResponse = {
@@ -175,7 +175,8 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
       moderationEnabled = false,
       routingApprovalEnabled = false,
       lockedDown = false,
-      apiLockedDown = false)
+      apiLockedDown = false,
+      unmigratedNbeEnabled = false)
     val resource = j"""{ "name" : "Just A Test", "I'm" : "OK", "you're" : "so-so" }"""
 
     val searchResults = Format.formatDocumentResponse(FormatParamSet(), domainSet, searchResponse)
@@ -209,7 +210,8 @@ class SearchServiceSpec extends FunSuiteLike with Matchers with BeforeAndAfterAl
   test("SearchResponse does not throw on bad documents it just ignores them") {
     val domain = Domain(1, "tempuri.org", Some("Title"), Some("Temp Org"),
                         isCustomerDomain = true, moderationEnabled = false,
-                        routingApprovalEnabled = false, lockedDown = false, apiLockedDown = false)
+                        routingApprovalEnabled = false, lockedDown = false,
+                        apiLockedDown = false, unmigratedNbeEnabled = false)
 
     val expectedResource = j"""{ "name" : "Just A Test", "I'm" : "OK", "you're" : "so-so" }"""
     val searchResults = Format.formatDocumentResponse(FormatParamSet(), domainSet, badSearchResponse)


### PR DESCRIPTION
#### What it do
Fixes a bug where we display a result to a dataset only on the NBE on domains that can't show NBE only datasets (ends up redirecting to the landing page). 

#### How was it tested?
* Ran queries locally against the ES index in staging to verify that only the intended results were filtered 
* sbt test 