### PR TITLE
UserSearch: support search by flags.

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/ParamSets.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/ParamSets.scala
@@ -41,6 +41,7 @@ case class UserSearchParamSet(
     ids: Option[Set[String]] = None,
     emails: Option[Set[String]] = None,
     screenNames: Option[Set[String]] = None,
+    flags: Option[Set[String]] = None,
     roles: Option[Set[String]] = None,
     domain: Option[String] = None,
     query: Option[String] = None)

--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/QueryParametersParser.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/QueryParametersParser.scala
@@ -259,6 +259,9 @@ object QueryParametersParser { // scalastyle:ignore number.of.methods
   def prepareScreenName(queryParameters: MultiQueryParams): Option[Set[String]] =
     filterNonEmptySetParams(mergeArrayCommaParams(queryParameters, Params.filterScreenName))
 
+  def prepareFlag(queryParameters: MultiQueryParams): Option[Set[String]] =
+    filterNonEmptySetParams(mergeArrayCommaParams(queryParameters, Params.filterFlag))
+
   def prepareRole(queryParameters: MultiQueryParams): Option[Set[String]] =
     filterNonEmptySetParams(mergeArrayCommaParams(queryParameters, Params.filterRole))
 
@@ -327,6 +330,7 @@ object QueryParametersParser { // scalastyle:ignore number.of.methods
        prepareUserId(queryParameters),
        prepareEmail(queryParameters),
        prepareScreenName(queryParameters),
+       prepareFlag(queryParameters),
        prepareRole(queryParameters),
        prepareUserDomain(queryParameters),
        prepareUserQuery(queryParameters)
@@ -361,6 +365,7 @@ object Params {
   val filterId = "ids"
   val filterEmail = "emails"
   val filterScreenName = "screen_names"
+  val filterFlag = "flags"
   val filterRole = "roles"
   val filterDomain = "domain"
 

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -306,6 +306,9 @@ object UserFilters {
   def screenNameFilter(screenNames: Option[Set[String]]): Option[FilterBuilder] =
     screenNames.map(s => termsFilter(UserScreenName.rawFieldName, s.toSeq: _*))
 
+  def flagFilter(flags: Option[Set[String]]): Option[FilterBuilder] =
+    flags.map(r => termsFilter(UserFlag.fieldName, r.toSeq: _*))
+
   def roleFilter(roles: Option[Set[String]]): Option[FilterBuilder] =
     roles.map(r => termsFilter(UserRole.fieldName, r.toSeq: _*))
 
@@ -328,6 +331,7 @@ object UserFilters {
       idFilter(searchParams.ids),
       emailFilter(searchParams.emails),
       screenNameFilter(searchParams.screenNames),
+      flagFilter(searchParams.flags),
       nestedRolesFilter(searchParams.roles, domainId)
     ).flatten
     if (filters.isEmpty) {

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -265,6 +265,10 @@ case object UserEmail extends UserFieldType with Rawable {
   val fieldName: String = "email"
 }
 
+case object UserFlag extends UserFieldType {
+  val fieldName: String = "flags"
+}
+
 case object UserRole extends UserFieldType {
   val fieldName: String = "roles.role_name"
 }

--- a/cetera-http/src/test/resources/users.tsv
+++ b/cetera-http/src/test/resources/users.tsv
@@ -2,5 +2,5 @@ id	displayName	email	domainId	roleName	flags	imageLarge	imageMedium	imageSmall
 death	death	death@city.org	0	death	symmetrical	""	""	""
 soul-eater	death the kid	death.kid@deathcity.com	0	headmaster		/api/users/soul-eater/profile_images/LARGE	/api/users/soul-eater/profile_images/THUMB	/api/users/soul-eater/profile_images/TINY
 dark-soul	dark-star	dark.star@deathcity.com	0	assasin		/api/users/soul-eater2/profile_images/LARGE	/api/users/soul-eater2/profile_images/THUMB	/api/users/soul-eater2/profile_images/TINY
-fun-shine	Funshine Bear	funshine.bear@care.alot	1	bear	yellow  ""	""	""
-good-luck	Goodluck Bear	good.luck.bear@care.alot	1	bear	green   ""	""	""
+fun-shine	Funshine Bear	funshine.bear@care.alot	1	bear	yellow	""	""	""
+good-luck	Goodluck Bear	good.luck.bear@care.alot	1	bear	green	""	""	""

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
@@ -43,10 +43,10 @@ trait TestESData {
         screenName = Option(tsvLine(1)).filter(_.nonEmpty),
         email = Option(tsvLine(2)).filter(_.nonEmpty),
         roles = Some(Set(Role(tsvLine(3).toInt, tsvLine(4)))),
-        flags = Option(List(tsvLine(4)).filter(_.nonEmpty)),
-        profileImageUrlLarge = Option(tsvLine(5)).filter(_.nonEmpty),
-        profileImageUrlMedium = Option(tsvLine(6)).filter(_.nonEmpty),
-        profileImageUrlSmall = Option(tsvLine(7)).filter(_.nonEmpty)
+        flags = Option(List(tsvLine(5)).filter(_.nonEmpty)),
+        profileImageUrlLarge = Option(tsvLine(6)).filter(_.nonEmpty),
+        profileImageUrlMedium = Option(tsvLine(7)).filter(_.nonEmpty),
+        profileImageUrlSmall = Option(tsvLine(8)).filter(_.nonEmpty)
       )
     }.toSeq
   }

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/FiltersSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/FiltersSpec.scala
@@ -294,11 +294,21 @@ class FiltersSpec extends WordSpec with ShouldMatchers {
     }
   }
 
+  "UserFilters: flagFilter" should {
+    "return the expected filter" in {
+      val filter = UserFilters.flagFilter(Some(Set("admin"))).get
+      val actual = JsonReader.fromString(filter.toString)
+      val expected = j"""{"terms" : {"flags" : ["admin"]}}"""
+      actual should be(expected)
+    }
+  }
+
   "UserFilters: compositeFilter" should {
     "return the expected filter" in {
       val params = UserSearchParamSet(
         emails = Some(Set("admin@gmail.com")),
         screenNames = Some(Set("Ad men")),
+        flags = Some(Set("admin")),
         roles = Some(Set("admin"))
       )
       val filter = UserFilters.compositeFilter(params, Some(1042))
@@ -309,6 +319,7 @@ class FiltersSpec extends WordSpec with ShouldMatchers {
             "must": [
               { "terms": {"email.raw": ["admin@gmail.com"]}},
               { "terms": {"screen_name.raw": ["Ad men"]}},
+              { "terms": {"flags": ["admin"]}},
               {
                 "nested": {
                   "path": "roles",

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/UserClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/UserClientSpec.scala
@@ -85,6 +85,20 @@ class UserClientSpec extends FunSuiteLike with Matchers with TestESData with Bef
     totalCount should be(2)
   }
 
+  test("search by singular flag") {
+    val params = UserSearchParamSet(flags = Some(Set("symmetrical")))
+    val (userRes, totalCount, _) = userClient.search(params, PagingParamSet(), None)
+    userRes should contain theSameElementsAs (Seq(users(0)))
+    totalCount should be(1)
+  }
+
+  test("search by multiple flags") {
+    val params = UserSearchParamSet(flags = Some(Set("yellow", "green")))
+    val (userRes, totalCount, _) = userClient.search(params, PagingParamSet(), None)
+    userRes should contain theSameElementsAs (Seq(users(3), users(4)))
+    totalCount should be(2)
+  }
+
   test("search by all the exact match conditions") {
     val params = UserSearchParamSet(
       emails = Some(Set("good.luck.bear@care.alot")),


### PR DESCRIPTION
#### What it do?

Let's the user answer the query `catalog/v1/users?flags=admin`.

#### Why?

Because often the set of users the frontend cares about are those with roles on the domain + super admins.  So might as well, make it easy to get the super admins.  For what it's worth, the other possible flag is `nopassword`, and it's easy to imagine wanting to find those users as well.

#### How was it tested?

* sbt test styleCheck
* ran cetera and tried out queries. 