### PR TITLE
EN-8301: Hide from catalog flag

### DIFF
--- a/cetera-http/src/main/resources/mapping_document.json
+++ b/cetera-http/src/main/resources/mapping_document.json
@@ -208,6 +208,8 @@
         "user_id": { "type": "string", "index": "not_analyzed" },
         "type": { "type": "string", "index": "not_analyzed" }
       }
-    }
+    },
+    "hide_from_catalog": { "type": "boolean" },
+    "hide_from_data_json": { "type": "boolean" }
   }
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/ParamSets.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/ParamSets.scala
@@ -13,7 +13,8 @@ case class SearchParamSet(
     user: Option[String] = None,
     sharedTo: Option[String] = None,
     attribution: Option[String] = None,
-    parentDatasetId: Option[String] = None)
+    parentDatasetId: Option[String] = None,
+    showHidden: Boolean = false)
 
 case class ScoringParamSet(
     fieldBoosts: Map[CeteraFieldType with Boostable, Float] = Map.empty,

--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/QueryParametersParser.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/QueryParametersParser.scala
@@ -248,6 +248,9 @@ object QueryParametersParser { // scalastyle:ignore number.of.methods
       ).value
     )
 
+  def prepareShowHidden(queryParameters: MultiQueryParams): Boolean =
+    queryParameters.contains(Params.showHidden)
+
   //  user search param preparers
 
   def prepareUserId(queryParameters: MultiQueryParams): Option[Set[String]] =
@@ -303,7 +306,8 @@ object QueryParametersParser { // scalastyle:ignore number.of.methods
           prepareUsers(queryParameters),
           prepareSharedTo(queryParameters),
           prepareAttribution(queryParameters),
-          prepareParentDatasetId(queryParameters)
+          prepareParentDatasetId(queryParameters),
+          prepareShowHidden(queryParameters)
         )
         val scoringParams = ScoringParamSet(
           prepareFieldBoosts(queryParameters),
@@ -320,7 +324,8 @@ object QueryParametersParser { // scalastyle:ignore number.of.methods
         val formatParams = FormatParamSet(
           prepareShowScore(queryParameters),
           prepareShowVisiblity(queryParameters),
-          prepareLocale(queryParameters))
+          prepareLocale(queryParameters)
+        )
         Right(ValidatedQueryParameters(searchParams, scoringParams, pagingParams, formatParams))
     }
   }
@@ -357,6 +362,8 @@ object Params {
   val filterAttribution = "attribution"
   val filterParentDatasetId = "derived_from"
   val filterSharedTo = "shared_to"
+
+  val showHidden = "show_hidden"
 
   val queryAdvanced = "q_internal"
   val querySimple = "q"
@@ -455,7 +462,8 @@ object Params {
     showVisibility,
     scanLength,
     scanOffset,
-    sortOrder
+    sortOrder,
+    showHidden
   ) ++ datatypeBoostParams.toSet
 
   // If your param is an array like tags[]=fun&tags[]=ice+cream, add it here

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -174,6 +174,14 @@ case object IsPublishedFieldType extends DocumentFieldType {
   val fieldName: String = "is_published"
 }
 
+case object HideFromCatalogFieldType extends DocumentFieldType {
+  val fieldName: String = "hide_from_catalog"
+}
+
+case object HideFromDataJsonFieldType extends DocumentFieldType {
+  val fieldName: String = "hide_from_data_json"
+}
+
 
 /////////////////////////////////////////////////
 // Domain-specific Categories, Tags, and Metadata

--- a/cetera-http/src/test/resources/views/fxf-0.json
+++ b/cetera-http/src/test/resources/views/fxf-0.json
@@ -76,5 +76,7 @@
   "shared_to": [  ],
   "attribution": null,
   "preview_image_id": null,
-  "grants": []
+  "grants": [],
+  "hide_from_catalog": false,
+  "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/fxf-1.json
+++ b/cetera-http/src/test/resources/views/fxf-1.json
@@ -74,5 +74,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/fxf-10.json
+++ b/cetera-http/src/test/resources/views/fxf-10.json
@@ -74,5 +74,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/fxf-2.json
+++ b/cetera-http/src/test/resources/views/fxf-2.json
@@ -74,5 +74,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/fxf-3.json
+++ b/cetera-http/src/test/resources/views/fxf-3.json
@@ -74,5 +74,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/fxf-4.json
+++ b/cetera-http/src/test/resources/views/fxf-4.json
@@ -77,5 +77,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/fxf-5.json
+++ b/cetera-http/src/test/resources/views/fxf-5.json
@@ -74,5 +74,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/fxf-6.json
+++ b/cetera-http/src/test/resources/views/fxf-6.json
@@ -74,5 +74,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/fxf-7.json
+++ b/cetera-http/src/test/resources/views/fxf-7.json
@@ -74,5 +74,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/fxf-8.json
+++ b/cetera-http/src/test/resources/views/fxf-8.json
@@ -77,5 +77,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/fxf-9.json
+++ b/cetera-http/src/test/resources/views/fxf-9.json
@@ -74,5 +74,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/summary.txt
+++ b/cetera-http/src/test/resources/views/summary.txt
@@ -1,140 +1,189 @@
-fxf-0	domain 0: customer domain, no moderation, no R&A, not locked-down
+fxf-0	domain 0: customer domain, no moderation, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: None
 	isRoutingApproved: None
 	isDatalensApproved: None
 	visibleToAnonymous: Some(true)
-fxf-1	domain 1: not customer domain, is moderated, no R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+fxf-1	domain 1: not customer domain, is moderated, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: Some(true)
 	isRoutingApproved: None
 	isDatalensApproved: None
 	visibleToAnonymous: Some(true)
-fxf-2	domain 2: customer domain, not moderated, has R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+fxf-2	domain 2: customer domain, not moderated, has R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: None
 	isRoutingApproved: Some(false)
 	isDatalensApproved: Some(false)
 	visibleToAnonymous: Some(false)
-fxf-3	domain 3: customer domain, moderated, has R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+fxf-3	domain 3: customer domain, moderated, has R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: Some(true)
 	isRoutingApproved: Some(false)
 	isDatalensApproved: None
 	visibleToAnonymous: Some(false)
-fxf-4	domain 0: customer domain, no moderation, no R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+fxf-4	domain 0: customer domain, no moderation, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: None
 	isRoutingApproved: None
 	isDatalensApproved: None
 	visibleToAnonymous: Some(true)
-fxf-5	domain 1: not customer domain, is moderated, no R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+fxf-5	domain 1: not customer domain, is moderated, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: Some(false)
 	isRoutingApproved: None
 	isDatalensApproved: None
 	visibleToAnonymous: Some(false)
-fxf-6	domain 2: customer domain, not moderated, has R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+fxf-6	domain 2: customer domain, not moderated, has R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: None
 	isRoutingApproved: Some(false)
 	isDatalensApproved: None
 	visibleToAnonymous: Some(false)
-fxf-7	domain 3: customer domain, moderated, has R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+fxf-7	domain 3: customer domain, moderated, has R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: Some(false)
 	isRoutingApproved: Some(false)
 	isDatalensApproved: None
 	visibleToAnonymous: Some(false)
-fxf-8	domain 0: customer domain, no moderation, no R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+fxf-8	domain 0: customer domain, no moderation, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: None
 	isRoutingApproved: None
 	isDatalensApproved: None
 	visibleToAnonymous: Some(true)
-fxf-9	domain 1: not customer domain, is moderated, no R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+fxf-9	domain 1: not customer domain, is moderated, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: Some(false)
 	isRoutingApproved: None
 	isDatalensApproved: None
 	visibleToAnonymous: Some(false)
-fxf-10	domain 2: customer domain, not moderated, has R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+fxf-10	domain 2: customer domain, not moderated, has R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: None
 	isRoutingApproved: Some(true)
 	isDatalensApproved: None
 	visibleToAnonymous: Some(true)
-zeta-0001	domain 0: customer domain, no moderation, no R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+zeta-0001	domain 0: customer domain, no moderation, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: None
 	isRoutingApproved: None
 	isDatalensApproved: None
 	visibleToAnonymous: Some(true)
-zeta-0002	domain 3: customer domain, moderated, has R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+zeta-0002	domain 3: customer domain, moderated, has R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: Some(true)
 	isRoutingApproved: Some(true)
 	isDatalensApproved: None
 	visibleToAnonymous: Some(true)
-zeta-0003	domain 0: customer domain, no moderation, no R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+zeta-0003	domain 0: customer domain, no moderation, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(false)
 	isPublished: Some(true)
 	isModerationApproved: None
 	isRoutingApproved: None
 	isDatalensApproved: None
 	visibleToAnonymous: Some(false)
-zeta-0004	domain 0: customer domain, no moderation, no R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+zeta-0004	domain 0: customer domain, no moderation, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: None
 	isRoutingApproved: None
 	isDatalensApproved: Some(false)
 	visibleToAnonymous: Some(false)
-zeta-0005	domain 3: customer domain, moderated, has R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+zeta-0005	domain 3: customer domain, moderated, has R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: Some(true)
 	isRoutingApproved: Some(true)
 	isDatalensApproved: None
 	visibleToAnonymous: Some(true)
-zeta-0006	domain 0: customer domain, no moderation, no R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+zeta-0006	domain 0: customer domain, no moderation, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(false)
 	isModerationApproved: None
 	isRoutingApproved: None
 	isDatalensApproved: None
 	visibleToAnonymous: Some(false)
-zeta-0007	domain 0: customer domain, no moderation, no R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+zeta-0007	domain 0: customer domain, no moderation, no R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: None
 	isRoutingApproved: None
 	isDatalensApproved: None
 	visibleToAnonymous: Some(true)
-zeta-0008	domain 8: customer domain, moderated, has R&A, is locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+zeta-0008	domain 8: customer domain, moderated, has R&A, is locked-down, not hidden from catalog or data.json
 	isPublic: Some(true)
 	isPublished: Some(true)
 	isModerationApproved: Some(true)
 	isRoutingApproved: Some(true)
 	isDatalensApproved: Some(true)
 	visibleToAnonymous: Some(true)
-zeta-0009	domain 3: customer domain, moderated, has R&A, not locked-down
+    hideFromCatalog: false
+    hideFromDataJson: false
+zeta-0009	domain 3: customer domain, moderated, has R&A, not locked-down, not hidden from catalog or data.json
 	isPublic: Some(false)
 	isPublished: Some(true)
 	isModerationApproved: Some(true)
 	isRoutingApproved: Some(true)
 	isDatalensApproved: None
 	visibleToAnonymous: Some(false)
+    hideFromCatalog: false
+    hideFromDataJson: false
+zeta-0010	domain 3: customer domain, moderated, has R&A, not locked-down, hidden from catalog and data.json
+	isPublic: Some(false)
+	isPublished: Some(true)
+	isModerationApproved: Some(true)
+	isRoutingApproved: Some(true)
+	isDatalensApproved: None
+	visibleToAnonymous: Some(false)
+    hideFromCatalog: true
+    hideFromDataJson: true

--- a/cetera-http/src/test/resources/views/zeta-0001.json
+++ b/cetera-http/src/test/resources/views/zeta-0001.json
@@ -73,5 +73,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/zeta-0002.json
+++ b/cetera-http/src/test/resources/views/zeta-0002.json
@@ -73,5 +73,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/zeta-0003.json
+++ b/cetera-http/src/test/resources/views/zeta-0003.json
@@ -74,5 +74,7 @@
  "shared_to": [ "Little John" ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/zeta-0004.json
+++ b/cetera-http/src/test/resources/views/zeta-0004.json
@@ -73,5 +73,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/zeta-0005.json
+++ b/cetera-http/src/test/resources/views/zeta-0005.json
@@ -73,5 +73,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/zeta-0006.json
+++ b/cetera-http/src/test/resources/views/zeta-0006.json
@@ -73,5 +73,7 @@
  "shared_to": [ "Little John" ],
  "attribution": null,
  "preview_image_id": null,
-  "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/zeta-0008.json
+++ b/cetera-http/src/test/resources/views/zeta-0008.json
@@ -73,5 +73,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
- "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/zeta-0009.json
+++ b/cetera-http/src/test/resources/views/zeta-0009.json
@@ -73,5 +73,7 @@
  "shared_to": [  ],
  "attribution": null,
  "preview_image_id": null,
- "grants": []
+ "grants": [],
+ "hide_from_catalog": false,
+ "hide_from_data_json": false
 }

--- a/cetera-http/src/test/resources/views/zeta-0010.json
+++ b/cetera-http/src/test/resources/views/zeta-0010.json
@@ -2,25 +2,25 @@
   "created_at" : "2016-09-19T10:37:20.933-07:00",
   "updated_at" : "2016-09-19T10:37:20.857-07:00",
   "socrata_id": {
-   "dataset_id": "zeta-0007",
+   "dataset_id": "zeta-0009",
    "parent_dataset_id": [],
-   "domain_id": 0,
-   "nbe_id": "zeta-0007",
-   "obe_id": "data-0007"
+   "domain_id": 3,
+   "nbe_id": "zeta-009",
+   "obe_id": "data-0009"
  },
  "resource": {
-   "description": "a dataset with attribution",
-   "nbe_fxf": "zeta-0007",
+   "description": "private chart",
+   "nbe_fxf": "zeta-0009",
    "parent_fxf": null,
-   "updated_at": "2016-09-19T10:37:21.149-07:00",
-   "created_at": "2016-09-19T10:37:21.149-07:00",
-   "type": "dataset",
-   "id": "zeta-0007",
+   "updated_at": "2016-09-19T10:37:21.153-07:00",
+   "created_at": "2016-09-19T10:37:21.153-07:00",
+   "type": "chart",
+   "id": "zeta-0009",
    "columns": [
 
    ],
    "name": "",
-   "attribution": "The Merry Men"
+   "attribution": null
  },
  "animl_annotations": {
    "categories": [
@@ -30,7 +30,7 @@
 
    ]
  },
- "datatype": "dataset",
+ "datatype": "chart",
  "viewtype": "",
  "popularity": 0.0,
  "indexed_metadata": {
@@ -47,12 +47,12 @@
    ]
  },
  "customer_metadata_flattened": [],
- "is_public": true,
+ "is_public": false,
  "is_published": true,
- "is_default_view": true,
+ "is_default_view": false,
  "is_moderation_approved": true,
  "approving_domain_ids": [
-   0,1,2,3
+   3
  ],
  "is_approved_by_parent_domain": true,
  "page_views": {
@@ -62,18 +62,18 @@
  },
  "customer_category": "Fun",
  "customer_tags": [
-
+   "fake","king"
  ],
  "update_freq": 0,
- "owner_id": "lil-john",
+ "owner_id": "prince-john",
  "owner" : {
-   "id": "lil-john",
-   "screen_name": "Little John"
+   "id": "prince-john",
+   "screen_name": "Prince John"
  },
- "shared_to": [ "King Richard" ],
- "attribution": "The Merry Men",
- "preview_image_id": "123456789",
+ "shared_to": [  ],
+ "attribution": null,
+ "preview_image_id": null,
  "grants": [],
- "hide_from_catalog": false,
- "hide_from_data_json": false
+ "hide_from_catalog": true,
+ "hide_from_data_json": true
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
@@ -66,4 +66,3 @@ trait TestESData extends TestESDomains with TestESUsers {
       .execute.actionGet
   }
 }
-


### PR DESCRIPTION
**What it do**

Respects the `hide_from_catalog` field in ES and will not show those entries as results unless `show_hidden` is passed as a flag. 

*How was it tested*
sbt test passes locally. Testing by hand is not possible yet as there is no data with hide_from_catalog in ES, but it will be super easy to test once that exists! 