### PR TITLE
Hunter/en 9147/revert changes

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Filters.scala
@@ -144,24 +144,6 @@ object DocumentFilters {
     if (searchContextIsModerated) contextualFilter else basicFilter
   }
 
-
-  /**
-    * @param enabledIds Ids of domains that have enabled showing NBE documents
-    *                   even if there is no OBE copy of that document
-    * @return A FilterBuilder to remove any NBE only documents for domains that
-    *         require OBE to show
-    */
-  def unmigratedNbeFilter(enabledIds: Set[Int]): FilterBuilder = {
-    val parentDomainAllowsUnmigrated =
-      Some(enabledIds).filter(_.nonEmpty).map(domainIdsFilter(_))
-
-    val filter = boolFilter()
-    filter.should(existsFilter(SocrataIdObeIdFieldType.fieldName))
-    parentDomainAllowsUnmigrated.foreach(filter.should)
-
-    filter
-  }
-
   /**
     * Filter to only show or aggregate documents that have passed the routing & approval workflow
     *
@@ -250,9 +232,7 @@ object DocumentFilters {
       None
     }
 
-    val unmigratedFilter = Some(unmigratedNbeFilter(domainSet.unmigratedNbeEnabledIds))
-
-    List(privacyFilter, publicationFilter, modStatusFilter, raFilter, unmigratedFilter).flatten
+    List(privacyFilter, publicationFilter, modStatusFilter, raFilter).flatten
   }
 
   def visibilityUserOverrideFilters(

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/DomainSet.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/DomainSet.scala
@@ -43,5 +43,4 @@ case class DomainSet(
   val allIds = domains.map(_.domainId)
   val (moderationEnabledIds, moderationDisabledIds) = partitionIds(_.moderationEnabled)
   val (_, raDisabledIds) = partitionIds(_.routingApprovalEnabled)
-  val (unmigratedNbeEnabledIds, _) = partitionIds(_.unmigratedNbeEnabled)
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
@@ -443,18 +443,6 @@ trait TestESData {
         attribution = None, previewImageId = None,
         Some("zeta-009"), Some("data-0009")
       )),
-      // This document is a essentially a copy of "zeta-0008" but should never show up as a result because
-      // it is a NBE only dataset on a domain that does not display NBE only datasets
-      (10, buildEsDoc(
-        "zeta-0010", None, 0,
-        "a nbe only dataset",  "zeta-0009", DateTime.now.toString, DateTime.now.toString,
-        "zeta-0010", Seq.empty, "", None, Map.empty, Map.empty, TypeDatasets.singular, viewtype = "", 0F,
-        "", "", Seq.empty, Seq.empty, Seq.empty,
-        Map.empty,
-        isPublic = true, isPublished = true, isDefaultView = true, Some(true), Seq(0), isApprovedByParentDomain = true,
-        "42", "Fun", List("fake", "king"), 0L, "barack-obama", "Barack Obama", Seq.empty,
-        attribution = None, previewImageId = None,
-        Some("zeta-0010"), None
       ))
     ).foreach { case (domain, doc) =>
       client.client.prepareIndex(testSuiteName, esDocumentType)

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
@@ -442,7 +442,6 @@ trait TestESData {
         "42", "Fun", List("fake", "king"), 0L, "prince-john", "Prince John", Seq.empty,
         attribution = None, previewImageId = None,
         Some("zeta-009"), Some("data-0009")
-      )),
       ))
     ).foreach { case (domain, doc) =>
       client.client.prepareIndex(testSuiteName, esDocumentType)

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESDataSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESDataSpec.scala
@@ -67,7 +67,7 @@ class TestESDataSpec extends FunSuiteLike with Matchers with TestESData with Bef
 
   test("test documents are bootstrapped") {
     val res = client.client.prepareSearch().setTypes(esDocumentType).execute.actionGet
-    val numDocs = Datatypes.materialized.length + 10
+    val numDocs = Datatypes.materialized.length + 9
     res.getHits.getTotalHits should be(numDocs)
   }
 

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentClientSpec.scala
@@ -119,7 +119,6 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
   val raApprovedFilter = j"""{"term": {"is_approved_by_parent_domain": true}}"""
   val moderationFilter = j"""{"bool": { "should": [$defaultViewFilter, $modApprovedFilter]}}"""
   val routingApprovalFilter = j"""{"bool": {"must": {"bool": {"should": $raApprovedFilter}}}}"""
-  val unmigratedNbeFilter = j"""{"bool": {"should": {"exists": {"field": "socrata_id.obe_id"}}}}"""
 
   val defaultFilter = j"""{
     "bool": {
@@ -128,8 +127,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         ${publicFilter},
         ${publishedFilter},
         ${moderationFilter},
-        ${routingApprovalFilter},
-        ${unmigratedNbeFilter}]}
+        ${routingApprovalFilter}]}
   }"""
 
   val defaultFilterPlusDomainIds = j"""{
@@ -139,8 +137,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
         ${publishedFilter},
         ${domainsFilter},
         ${moderationFilter},
-        ${routingApprovalFilter},
-        ${unmigratedNbeFilter}]}
+        ${routingApprovalFilter}]}
   }"""
 
   val datatypeDatasetsFilter = j"""{
@@ -218,8 +215,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
               ${publicFilter},
               ${publishedFilter},
               ${moderationFilter},
-              ${routingApprovalFilter},
-              ${unmigratedNbeFilter}
+              ${routingApprovalFilter}
             ]
           }
         },
@@ -312,8 +308,7 @@ class DocumentClientSpec extends WordSpec with ShouldMatchers with BeforeAndAfte
               {"bool" :{"must" :{"bool" :{"should" :[
                 $domain42Filter,
                 $raApprovedFilter
-              ]}}}},
-              {"bool": {"should": {"exists": {"field": "socrata_id.obe_id"}}}}
+              ]}}}}
             ]}},
             $domain42Filter
           ]}},

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/FiltersSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/FiltersSpec.scala
@@ -213,30 +213,6 @@ class FiltersSpec extends WordSpec with ShouldMatchers {
     }
   }
 
-  "DocumentFilters: unmigratedNbeFilter" should {
-    "return the expected filter when given no domain ids" in {
-      val filter = DocumentFilters.unmigratedNbeFilter(Set())
-      val actual = JsonReader.fromString(filter.toString)
-      val expected =
-        j"""{"bool": {"should":
-              {"exists": {"field": "socrata_id.obe_id" }}
-            }}"""
-      actual should be(expected)
-    }
-
-
-    "return the expected filter when given domains with unmigrated_nbe_enabled turned on" in {
-      val filter = DocumentFilters.unmigratedNbeFilter(Set(1, 2, 3))
-      val actual = JsonReader.fromString(filter.toString)
-      val expected =
-        j"""{"bool": {"should": [
-              {"exists": {"field": "socrata_id.obe_id" }},
-              {"terms": {"socrata_id.domain_id": [1, 2, 3] }}
-            ]}}"""
-      actual should be(expected)
-    }
-  }
-
   "DocumentFilters: publicFilter" should {
     "return the expected filter" in {
       val filter = DocumentFilters.publicFilter(false)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.10-SNAPSHOT"
+version in ThisBuild := "1.2.9"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.9"
+version in ThisBuild := "1.2.9-SNAPSHOT"


### PR DESCRIPTION
Reverting our change that caused a SEV-1 when we hid all datalens' from the catalog. Also undoes the deploy stuff we did.

Sbt tests run locally.