### PR TITLE
Kavedder/en 13074/add license

### DIFF
--- a/cetera-http/src/main/resources/mapping_document.json
+++ b/cetera-http/src/main/resources/mapping_document.json
@@ -253,6 +253,7 @@
       "copy_to": [ "fts_analyzed", "fts_raw" ]
     },
     "preview_image_id": { "type": "string", "index": "no" },
-    "provenance": { "type": "string", "index": "not_analyzed" }
+    "provenance": { "type": "string", "index": "not_analyzed" },
+    "license": { "type": "string", "index": "not_analyzed" }
   }
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/ParamSets.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/ParamSets.scala
@@ -20,7 +20,8 @@ case class SearchParamSet(
     published: Option[Boolean] = None,
     derived: Option[Boolean] = None,
     explicitlyHidden: Option[Boolean] = None,
-    approvalStatus: Option[ApprovalStatus] = None)
+    approvalStatus: Option[ApprovalStatus] = None,
+    license: Option[String] = None)
 
 case class ScoringParamSet(
     fieldBoosts: Map[CeteraFieldType with Boostable, Float] = Map.empty,

--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/QueryParametersParser.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/QueryParametersParser.scala
@@ -210,6 +210,9 @@ object QueryParametersParser { // scalastyle:ignore number.of.methods
   def prepareHidden(queryParameters: MultiQueryParams): Option[Boolean] =
     prepareBooleanParam(queryParameters, Params.explicitlyHidden)
 
+  def prepareLicense(queryParameters: MultiQueryParams): Option[String] =
+    filterNonEmptyStringParams(queryParameters.first(Params.license))
+
   def prepareApprovalStatus(queryParameters: MultiQueryParams): Option[ApprovalStatus] = {
     val status = filterNonEmptyStringParams(queryParameters.first(Params.approvalStatus))
     status.map(restrictApprovalFilter(_))
@@ -339,7 +342,8 @@ object QueryParametersParser { // scalastyle:ignore number.of.methods
       preparePublished(queryParameters),
       prepareDerived(queryParameters),
       prepareHidden(queryParameters),
-      prepareApprovalStatus(queryParameters)
+      prepareApprovalStatus(queryParameters),
+      prepareLicense(queryParameters)
     )
 
     val scoringParams = ScoringParamSet(
@@ -400,6 +404,7 @@ object Params {
   val derived = "derived"
   val explicitlyHidden = "explicitly_hidden"
   val approvalStatus = "approval_status"
+  val license = "license"
 
   val qInternal = "q_internal"
   val q = "q"
@@ -505,7 +510,8 @@ object Params {
     showVisibility,
     limit,
     offset,
-    order
+    order,
+    license
   ) ++ datatypeBoostParams.toSet
 
 

--- a/cetera-http/src/main/scala/com/socrata/cetera/response/Format.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/response/Format.scala
@@ -155,6 +155,8 @@ object Format {
 
   def previewImageId(j: JValue): Option[String] = extractJString(j.dyn.preview_image_id.?)
 
+  def license(j: JValue): Option[String] = extractJString(j.dyn.license.?)
+
   def isPublic(j: JValue): Boolean = extractJBoolean(j.dyn.is_public.?).exists(identity)
 
   def isPublished(j: JValue): Boolean = extractJBoolean(j.dyn.is_published.?).exists(identity)
@@ -237,9 +239,11 @@ object Format {
       routingApproval.getOrElse(true) & routingApprovalOnContext.getOrElse(true) &
       moderationApproval.getOrElse(true) & moderationApprovalOnContext.getOrElse(true) &
       datalensApproval.getOrElse(true)
+    val viewLicense = license(j)
 
     Metadata(
       domain = viewsDomain.domainCname,
+      license = viewLicense,
       isPublic = Some(public),
       isPublished = Some(published),
       isModerationApproved = moderationApproval,
@@ -251,7 +255,7 @@ object Format {
       grants = viewGrants)
   }
 
-  def documentSearchResult(
+  def documentSearchResult( // scalastyle:ignore method.length
       j: JValue,
       user: Option[User],
       domainSet: DomainSet,
@@ -263,11 +267,12 @@ object Format {
       val viewsDomainId = domainId(j).getOrElse(throw new NoSuchElementException)
       val domainIdCnames = domainSet.idMap.map { case (i, d) => i -> d.domainCname }
       val viewsDomain = domainSet.idMap.getOrElse(viewsDomainId, throw new NoSuchElementException)
+      val viewLicense = license(j)
       val scoreMap = score.map(s => s.toBigDecimal)
       val scorelessMetadata = if (showVisibility) {
         calculateVisibility(j, viewsDomain, domainSet)
       } else {
-        Metadata(viewsDomain.domainCname)
+        Metadata(viewsDomain.domainCname, viewLicense)
       }
 
       val metadata = scorelessMetadata.copy(score = score.map(_.toBigDecimal))

--- a/cetera-http/src/main/scala/com/socrata/cetera/response/JsonResponses.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/response/JsonResponses.scala
@@ -61,6 +61,7 @@ object Classification {
 @JsonKeyStrategy(Strategy.Underscore)
 case class Metadata(
     domain: String,
+    license: Option[String],
     isPublic: Option[Boolean] = None,
     isPublished: Option[Boolean] = None,
     isModerationApproved: Option[Boolean] = None,

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Aggregations.scala
@@ -70,6 +70,13 @@ object DocumentAggregations {
       .order(Terms.Order.count(false))
       .size(aggSize)
 
+  val license =
+    AggregationBuilders
+      .terms("license")
+      .field(LicenseFieldType.rawFieldName)
+      .order(Terms.Order.count(false))
+      .size(aggSize)
+
   def chooseAggregation(field: DocumentFieldType with Countable with Rawable): AbstractAggregationBuilder =
     field match {
       case DomainCategoryFieldType => domainCategories
@@ -81,6 +88,7 @@ object DocumentAggregations {
       case OwnerIdFieldType => owners
       case AttributionFieldType => attributions
       case ProvenanceFieldType => provenance
+      case LicenseFieldType => license
     }
 }
 

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentFilters.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentFilters.scala
@@ -29,6 +29,9 @@ object DocumentFilters {
   def provenanceFilter(provenance: String, aggPrefix: String = ""): FilterBuilder =
     termFilter(aggPrefix + ProvenanceFieldType.rawFieldName, provenance)
 
+  def licenseFilter(license: String, aggPrefix: String = ""): FilterBuilder =
+    termFilter(aggPrefix + LicenseFieldType.rawFieldName, license)
+
   def parentDatasetFilter(parentDatasetId: String, aggPrefix: String = ""): FilterBuilder =
     termFilter(aggPrefix + ParentDatasetIdFieldType.fieldName, parentDatasetId)
 
@@ -320,6 +323,7 @@ object DocumentFilters {
     val idsFilter = searchParams.ids.map(idFilter(_))
     val metaFilter = searchParams.domainMetadata.flatMap(combinedMetadataFilter(_, user))
     val derivationFilter = searchParams.derived.map(derivedFilter(_))
+    val licensesFilter = searchParams.license.map(licenseFilter(_))
 
     // the params below are those that would also influence visibility. these can only serve to further
     // limit the set of views returned from what the visibilityFilters allow.
@@ -329,7 +333,7 @@ object DocumentFilters {
     val approvalFilter = searchParams.approvalStatus.map(approvalStatusFilter(_, domainSet))
 
     List(typeFilter, ownerFilter, sharingFilter, attrFilter, provFilter, parentIdFilter, idsFilter, metaFilter,
-      derivationFilter, privacyFilter, publicationFilter, hiddenFilter, approvalFilter).flatten match {
+      derivationFilter, privacyFilter, publicationFilter, hiddenFilter, approvalFilter, licensesFilter).flatten match {
       case Nil => None
       case filters: Seq[FilterBuilder] => Some(filters.foldLeft(boolFilter()) { (b, f) => b.must(f) })
     }

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -98,6 +98,7 @@ class CountService(
       case OwnerIdFieldType => Count.encode("owner_id")
       case AttributionFieldType => Count.encode("attribution")
       case ProvenanceFieldType => Count.encode("provenance")
+      case LicenseFieldType => Count.encode("license")
     }
 
     try {

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/Document.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/Document.scala
@@ -119,7 +119,8 @@ case class Document(
     grants: Seq[ESGrant],
     hideFromCatalog: Option[Boolean],
     hideFromDataJson: Option[Boolean],
-    moderationStatus: Option[String]) {
+    moderationStatus: Option[String],
+    license: Option[String]) {
 
   def isSharedOrOwned(userId: String): Boolean = ownerId == userId || sharedTo.contains(userId)
   def isDatalens: Boolean = datatype.startsWith("datalens")

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -115,7 +115,6 @@ case object TagsFieldType extends DocumentFieldType with Scorable with Rawable {
   }
 }
 
-// TODO: cetera-etl rename customer_category to domain_category
 // A domain category is a domain-specific (customer-specified) category (as
 // opposed to a Socrata-specific canonical category).
 case object DomainCategoryFieldType extends DocumentFieldType with Countable with Rawable {
@@ -136,6 +135,10 @@ case object AttributionFieldType extends DocumentFieldType with Countable with R
 
 case object ProvenanceFieldType extends DocumentFieldType with Countable with NativelyRawable {
   val fieldName: String = "provenance"
+}
+
+case object LicenseFieldType extends DocumentFieldType with Countable with NativelyRawable {
+  val fieldName: String = "license"
 }
 
 /////////////////////

--- a/cetera-http/src/test/resources/views/fxf-12.json
+++ b/cetera-http/src/test/resources/views/fxf-12.json
@@ -84,5 +84,6 @@
   "preview_image_id": null,
   "grants": [],
   "hide_from_catalog": false,
-  "hide_from_data_json": false
+  "hide_from_data_json": false,
+  "license": "Academic Free License"
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/handlers/QueryParametersParserSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/handlers/QueryParametersParserSpec.scala
@@ -330,6 +330,7 @@ class QueryParametersParserSpec extends FunSuiteLike with Matchers {
     QueryParametersParser(Map("derived_from" -> Seq(""))).searchParamSet.parentDatasetId shouldNot be('defined)
     QueryParametersParser(Map("appoval" -> Seq(""))).searchParamSet.approvalStatus shouldNot be('defined)
     QueryParametersParser(Map("custom_metadata" -> Seq(""))).searchParamSet.parentDatasetId shouldNot be('defined)
+    QueryParametersParser(Map("license" -> Seq(""))).searchParamSet.license shouldNot be('defined)
     QueryParametersParser.prepUserParams(Map("role" -> Seq(""))).searchParamSet.roles shouldNot be('defined)
     QueryParametersParser.prepUserParams(Map("email" -> Seq(""))).searchParamSet.emails shouldNot be('defined)
     QueryParametersParser.prepUserParams(Map("screen_name" -> Seq(""))).searchParamSet.screenNames shouldNot be('defined)
@@ -449,5 +450,9 @@ class ParamsSpec extends FunSuiteLike with Matchers {
 
   test("iscatalogKey recognizes provenance") {
     Params.isCatalogKey("provenance") should be (true)
+  }
+
+  test("iscatalogKey recognizes license") {
+    Params.isCatalogKey("license") should be (true)
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentFiltersSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/DocumentFiltersSpec.scala
@@ -99,6 +99,22 @@ class DocumentFiltersSpec extends WordSpec with ShouldMatchers with TestESDomain
     }
   }
 
+  "the licenseFilter" should {
+    "return the expected filter if some license is given" in {
+      val attrFilter = DocumentFilters.licenseFilter("WTFPL")
+      val expected = j"""{ "term": { "license": "WTFPL" } }"""
+      val actual = JsonReader.fromString(attrFilter.toString)
+      actual should be(expected)
+    }
+
+    "return the expected filter if a prefix is used" in {
+      val attrFilter = DocumentFilters.licenseFilter("WTFPL", "document.")
+      val expected = j"""{ "term": { "document.license": "WTFPL" } }"""
+      val actual = JsonReader.fromString(attrFilter.toString)
+      actual should be(expected)
+    }
+  }
+
   "the parentDatasetFilter" should {
     "return the expected filter if some id is given" in {
       val pdFilter = DocumentFilters.parentDatasetFilter("wonder-woman")
@@ -910,7 +926,8 @@ class DocumentFiltersSpec extends WordSpec with ShouldMatchers with TestESDomain
         sharedTo = Some("ro-bear"),
         attribution = Some("org"),
         parentDatasetId = Some("parent-id"),
-        ids = Some(Set("id-one", "id-two"))
+        ids = Some(Set("id-one", "id-two")),
+        license = Some("GNU GPL")
       )
       val user = User("ro-bear")
       val filter = DocumentFilters.searchParamsFilter(searchParams, Some(user), DomainSet()).get
@@ -929,7 +946,8 @@ class DocumentFiltersSpec extends WordSpec with ShouldMatchers with TestESDomain
                 {"bool" :{"should" :{"nested" :{"filter" :{"bool" :{"must" :[
                   {"terms" :{"customer_metadata_flattened.key.raw" :[ "key" ]}},
                   {"terms" :{"customer_metadata_flattened.value.raw" :[ "value" ]}}
-                ]}}, "path" : "customer_metadata_flattened"}}}}
+                ]}}, "path" : "customer_metadata_flattened"}}}},
+                { "term" : { "license" : "GNU GPL" } }
               ]
           }
       }

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpecForAnonymousUsers.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpecForAnonymousUsers.scala
@@ -436,6 +436,38 @@ class SearchServiceSpecForAnonymousUsers
     } should be(Some("official"))
   }
 
+  test("filtering by license works and the resulting metadata has a 'license' field") {
+    val params = Map("license" -> Seq("Academic Free License"))
+    val (_, results, _, _) = service.doSearch(params, false, AuthParams(), None, None)
+    results.results.headOption.map { case SearchResult(_, _, metadata, _, _, _) =>
+      metadata.license.get
+    } should be(Some("Academic Free License"))
+  }
+
+  test("filtering by license should be exact") {
+    val params = Map("license" -> Seq("Free License"))
+    val (_, results, _, _) = service.doSearch(params, false, AuthParams(), None, None)
+    results.results.headOption.map { case SearchResult(_, _, metadata, _, _, _) =>
+      metadata.license.get
+    } should be(None)
+  }
+
+  test("filtering by license should be case sensitive") {
+    val params = Map("license" -> Seq("academic free license"))
+    val (_, results, _, _) = service.doSearch(params, false, AuthParams(), None, None)
+    results.results.headOption.map { case SearchResult(_, _, metadata, _, _, _) =>
+      metadata.license.get
+    } should be(None)
+  }
+
+  test("a query that results in a dataset with a license should return metadata with a 'license' field") {
+    val params = Map("q" -> Seq("A dataset with a multiword title"))
+    val (_, results, _, _) = service.doSearch(params, false, AuthParams(), None, None)
+    results.results.headOption.map { case SearchResult(_, _, metadata, _, _, _) =>
+      metadata.license.get
+    } should be(Some("Academic Free License"))
+  }
+
   test("passing a datatype boost should have no effect on the size of the result set") {
     val (_, results, _, _) = service.doSearch(Map.empty, false, AuthParams(), None, None)
     val params = Map("boostFiles" -> Seq("2.0"))


### PR DESCRIPTION
Goes along with https://github.com/socrata/rammstein/pull/215

### What it do?
- understands a license facet, eg. `license=GNU+GPL`
- returns the license in the metadata instead of it being repeated in resource and top-level in ES

### How it tested?
- unit tests
- running rammstein and cetera locally, and searching for licenses