### PR TITLE
EN-12739 (part 1) have the facetService respect params

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/Router.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/Router.scala
@@ -48,10 +48,6 @@ class Router(
     Route("/catalog/tags", countResource(TagsFieldType)),
     Route("/catalog/v1/tags", countResource(TagsFieldType)),
 
-    // document counts for queries grouped by owner
-    Route("/catalog/owners", countResource(OwnerIdFieldType)),
-    Route("/catalog/v1/owners", countResource(OwnerIdFieldType)),
-
     // document counts for queries grouped by domain_category
     Route("/catalog/domain_categories", countResource(DomainCategoryFieldType)),
     Route("/catalog/v1/domain_categories", countResource(DomainCategoryFieldType)),

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/CountService.scala
@@ -91,6 +91,8 @@ class CountService(
   // scalastyle:ignore cyclomatic.complexity
   def aggregate(field: DocumentFieldType with Countable with Rawable)(req: HttpRequest): HttpResponse = {
     implicit val cEncode = field match {
+      // TODO: we only ever use the first 4 of these. We should maybe reconsider our trait organization in
+      // FieldTypes so it isn't necessary to include unused fields here.
       case CategoriesFieldType => Count.encode("category")
       case TagsFieldType => Count.encode("tag")
       case DomainCategoryFieldType => Count.encode("domain_category")

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -115,12 +115,6 @@ case object TagsFieldType extends DocumentFieldType with Scorable with Rawable {
   }
 }
 
-// A domain category is a domain-specific (customer-specified) category (as
-// opposed to a Socrata-specific canonical category).
-case object DomainCategoryFieldType extends DocumentFieldType with Countable with Rawable {
-  val fieldName: String = "customer_category"
-}
-
 case object OwnerIdFieldType extends DocumentFieldType with Countable with NativelyRawable {
   val fieldName: String = "owner_id"
 }
@@ -237,6 +231,12 @@ case object HideFromDataJsonFieldType extends DocumentFieldType {
 // Domain tags are customer-defined tags (which surface as topics in the front end).
 case object DomainTagsFieldType extends DocumentFieldType with Countable with Rawable {
   val fieldName: String = "customer_tags"
+}
+
+// A domain category is a domain-specific (customer-specified) category (as
+// opposed to a Socrata-specific canonical category).
+case object DomainCategoryFieldType extends DocumentFieldType with Countable with Rawable {
+  val fieldName: String = "customer_category"
 }
 
 // TODO: cetera-etl rename customer_metadata_flattened to domain_metadata_flattened

--- a/cetera-http/src/test/resources/views/zeta-0007.json
+++ b/cetera-http/src/test/resources/views/zeta-0007.json
@@ -70,6 +70,7 @@
   },
   "customer_category": "Fun",
   "customer_tags": [
+    "facts"
   ],
   "update_freq": 0,
   "owner_id": "lil-john",

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/CountServiceSpec.scala
@@ -152,7 +152,7 @@ class CountServiceSpecWithTestESData extends FunSuiteLike with Matchers with Bef
   }
 
   test("domain tags count request") {
-    val expectedResults = List(Count("1-one", 5), Count("2-two", 3))
+    val expectedResults = List(Count("1-one", 5), Count("2-two", 3), Count("facts",1))
     val (_, res, _, _) = countService.doAggregate(DomainTagsFieldType, Map.empty, AuthParams(), None, None)
     res.results should contain theSameElementsAs expectedResults
   }


### PR DESCRIPTION
#### What it do?

Teaches the facetService to respect params.

#### What it not do?

Has yet to teach the DomainCountService to respect params. That's a different beast entirely since it doesn't do search on /catalog/documents, but instead does search on /catalog/domains.

#### How is it tested?
New test, updated tests. Compared output of my local instance pointed at staging to actual staging.  Results match up for the basic query with no params and for the query with domains. All other queries with other params don't match up, cuz mine is better and respects the params.