### PR TITLE
Kavedder/en 14835/add provenance boost

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/ParamSets.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/ParamSets.scala
@@ -27,6 +27,7 @@ case class ScoringParamSet(
     fieldBoosts: Map[CeteraFieldType with Boostable, Float] = Map.empty,
     datatypeBoosts: Map[Datatype, Float] = Map.empty,
     domainBoosts: Map[String, Float] = Map.empty,
+    officialBoost: Float = 1.toFloat,
     minShouldMatch: Option[String] = None,
     slop: Option[Int] = None)
 

--- a/cetera-http/src/main/scala/com/socrata/cetera/handlers/QueryParametersParser.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/handlers/QueryParametersParser.scala
@@ -254,6 +254,9 @@ object QueryParametersParser { // scalastyle:ignore number.of.methods
     }
   }
 
+  def prepareOfficialBoost(queryParameters: MultiQueryParams): Float =
+    queryParameters.typedFirst[NonNegativeFloat](Params.boostOfficial).map(validated(_).value).getOrElse(1.0f)
+
   // Yes we compute searchQuery twice because this is a smell
   def prepareMinShouldMatch(queryParameters: MultiQueryParams): Option[String] = {
     val searchQuery = prepareSearchQuery(queryParameters)
@@ -345,6 +348,7 @@ object QueryParametersParser { // scalastyle:ignore number.of.methods
       prepareFieldBoosts(queryParameters),
       prepareDatatypeBoosts(queryParameters),
       prepareDomainBoosts(queryParameters),
+      prepareOfficialBoost(queryParameters),
       prepareMinShouldMatch(queryParameters),
       prepareSlop(queryParameters)
     )
@@ -450,6 +454,7 @@ object Params {
   // e.g., boostDomains[example.com]=1.23&boostDomains[data.seattle.gov]=4.56
   val boostDomains = boostParamPrefix + "Domains"
 
+  val boostOfficial = boostParamPrefix + "Official"
   val functionScore = "function_score"
   val minShouldMatch = "min_should_match"
   val slop = "slop"
@@ -470,7 +475,7 @@ object Params {
   // Explicit Param Lists
   ///////////////////////
 
-  // HEY! when adding/removing parameters update `keys` or `mapKeys` as appropriate.
+  // HEY! when adding/removing parameters update `catalog{String,Array,Map}Keys`  as appropriate.
   // These are used to distinguish catalog keys from custom metadata fields
 
   // If your param is a simple key/value pair, add it here
@@ -497,6 +502,7 @@ object Params {
     boostColumns,
     boostDescription,
     boostTitle,
+    boostOfficial,
     functionScore,
     minShouldMatch,
     slop,

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/Boosts.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/Boosts.scala
@@ -6,8 +6,7 @@ import org.elasticsearch.script.{Script, ScriptType}
 import org.elasticsearch.index.query.functionscore._
 import FunctionScoreQueryBuilder.FilterFunctionBuilder
 import org.elasticsearch.index.query.QueryBuilders.termQuery
-import com.socrata.cetera.types.{
-  Datatype, DatatypeFieldType, ScriptScoreFunction, SocrataIdDomainIdFieldType}
+import com.socrata.cetera.types._
 
 object Boosts {
   def datatypeBoostFunctions(
@@ -40,4 +39,18 @@ object Boosts {
           ScoreFunctionBuilders.weightFactorFunction(weight)
         )
     }.toList
+
+  val officialProvenance = "official"
+
+  def officialBoostFunction(
+    weight: Float)
+    : Option[FilterFunctionBuilder] =
+  weight match {
+    // It's not worth applying this filter in the case that it does nothing
+    case 1.0f => None
+    case _ => Some(new FilterFunctionBuilder(
+      termQuery(ProvenanceFieldType.fieldName, officialProvenance),
+      ScoreFunctionBuilders.weightFactorFunction(weight)))
+  }
+
 }

--- a/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentQueries.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/search/DocumentQueries.scala
@@ -617,7 +617,8 @@ case class DocumentQuery(forDomainSearch: Boolean = false) {
     val scoreFunctions = Boosts.scriptScoreFunctions(scriptScoreFunctions)
     val dataTypeBoosts = Boosts.datatypeBoostFunctions(scoringParams.datatypeBoosts)
     val domainBoosts = Boosts.domainBoostFunctions(domainSet.domainIdBoosts)
-    val allScoringFunctions = (scoreFunctions ++ dataTypeBoosts ++ domainBoosts)
+    val officialBoost = Boosts.officialBoostFunction(scoringParams.officialBoost)
+    val allScoringFunctions = scoreFunctions ++ dataTypeBoosts ++ domainBoosts ++ officialBoost
     val fnScoreQuery = functionScoreQuery(query, allScoringFunctions.toArray)
     fnScoreQuery.scoreMode(FnScoreMode.MULTIPLY).boostMode(CombineFunction.REPLACE)
   }

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/FieldTypes.scala
@@ -132,10 +132,6 @@ case object AttributionFieldType extends DocumentFieldType with Countable with R
   val fieldName: String = "attribution"
 }
 
-case object ProvenanceFieldType extends DocumentFieldType with Countable with NativelyRawable {
-  val fieldName: String = "provenance"
-}
-
 case object LicenseFieldType extends DocumentFieldType with Countable with NativelyRawable {
   val fieldName: String = "license"
 }
@@ -308,6 +304,10 @@ case object DatatypeFieldType extends DocumentFieldType with Boostable {
   val fieldName: String = "datatype"
 }
 
+case object ProvenanceFieldType extends DocumentFieldType with Countable with NativelyRawable with Boostable {
+  val fieldName: String = "provenance"
+}
+
 
 //////////////
 // For sorting
@@ -359,4 +359,3 @@ case object UserRole extends UserFieldType {
 case object UserDomainId extends UserFieldType {
   val fieldName: String = "roles.domain_id"
 }
-

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/BoostsSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/BoostsSpec.scala
@@ -23,7 +23,7 @@ class BoostsSpec extends WordSpec with ShouldMatchers {
       Boosts.datatypeBoostFunctions(datatypeBoosts).length shouldEqual(3)
     }
 
-    "add datatype boosts to the query" in {      
+    "add datatype boosts to the query" in {
       val datatypeBoosts = Map[Datatype, Float](
         DatasetDatatype -> 1.23f,
         DatalensDatatype -> 2.34f,
@@ -68,7 +68,7 @@ class BoostsSpec extends WordSpec with ShouldMatchers {
       actual should be (expected)
     }
 
-    "do nothing to the query if given no datatype boosts" in {      
+    "do nothing to the query if given no datatype boosts" in {
       val boostFunctions = Boosts.datatypeBoostFunctions(Map.empty[Datatype, Float])
       val query = QueryBuilders.functionScoreQuery(QueryBuilders.matchAllQuery, boostFunctions.toArray)
       val actual = JsonReader.fromString(query.toString)
@@ -82,7 +82,7 @@ class BoostsSpec extends WordSpec with ShouldMatchers {
               "boost": 1.0,
               "query": {"match_all": {"boost": 1.0}}
           }
-      }      
+      }
       """
 
       actual should be (expected)
@@ -159,6 +159,40 @@ class BoostsSpec extends WordSpec with ShouldMatchers {
       """
 
       actual should be(expected)
+    }
+  }
+
+  "boostOfficial" should {
+    "return None in the case of a boost of 1" in {
+      val boostFunction = Boosts.officialBoostFunction(1.0f)
+      boostFunction should be(None)
+    }
+
+    "add a boost to the official provenance type if given a provenance boost" in {
+      val boostFunction = Boosts.officialBoostFunction(2.0f).get
+      val query = QueryBuilders.functionScoreQuery(QueryBuilders.matchAllQuery, Array(boostFunction))
+      val actual = JsonReader.fromString(query.toString)
+
+      val expected = j"""
+      {
+          "function_score": {
+              "functions": [
+                  {
+                      "filter": {
+                          "term": {"provenance": {"value": "official", "boost": 1.0}}
+                      },
+                      "weight": 2.0
+                  }
+              ],
+              "score_mode": "multiply",
+              "max_boost": 3.4028235E+38,
+              "boost": 1.0,
+              "query": {"match_all": {"boost": 1.0}}
+          }
+      }
+      """
+
+      actual should be (expected)
     }
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/search/UserQueriesSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/search/UserQueriesSpec.scala
@@ -137,7 +137,7 @@ class UserQueriesSpec extends WordSpec with ShouldMatchers with TestESDomains {
         screenNames = Some(Set("Ad men")),
         flags = Some(Set("admin")),
         roles = Some(Set("admin")))
-      
+
       val user = User("", None, roleName = None, rights = None, flags = Some(List("admin")))
       val compositeQuery = UserQueries.compositeQuery(params, Some(domains(2)), Some(user))
       val actual = JsonReader.fromString(compositeQuery.toString)
@@ -149,7 +149,7 @@ class UserQueriesSpec extends WordSpec with ShouldMatchers with TestESDomains {
               {"terms": {"screen_name.raw": ["ad men"], "boost": 1.0}},
               {"terms": {"flags": ["admin"], "boost": 1.0}},
               {
-                "nested": {                  
+                "nested": {
                   "query": {
                     "bool": {
                       "must": [

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -220,7 +220,7 @@ class SearchServiceSpec extends FunSuiteLike
     wasSearchQueryLogged(metricsFile.getAbsolutePath, query) should be(true)
   }
 
-  test("if a domain is given in the searchContext and an advance query is given, the query should be logged") {
+  test("if a domain is given in the searchContext and an advanced query is given, the query should be logged") {
     val query = "(log this query OR don't) AND (check up on it OR don't)"
     val params = Map(
       "domains" -> "opendata-demo.socrata.com,petercetera.net",


### PR DESCRIPTION
this is still in progress. making a PR to keep notes in. 

`boostProvenance=2` seems pretty good -- here are the top results for `curl http://localhost:5704/catalog\?q\=test | jq ' .results[] | .resource.provenance'`:

```
"community"
"official"
"official"
"official"
"official"
"official"
"community"
"community"
"community"
"official"
"community"
"community"
"community"
"community"
"community"
"community"
"community"
"community"
"community"
"community"
"community"
```

All the top are "official" when `boostProvenance=2`.