### PR TITLE
EN-15539: provide frontend with matched text

### DIFF
--- a/cetera-http/src/test/resources/views/zeta-0007.json
+++ b/cetera-http/src/test/resources/views/zeta-0007.json
@@ -18,7 +18,7 @@
     "id": "zeta-0007",
     "columns": [
     ],
-    "name": "",
+    "name": "rammy is rammy",
     "attribution": "The Merry Men",
     "provenance": "community"
   },
@@ -31,7 +31,7 @@
   "datatype": "dataset",
   "viewtype": "",
   "indexed_metadata": {
-    "name": "",
+    "name": "rammy is rammy",
     "description": "",
     "columns_field_name": [
     ],

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/AutocompleteServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/AutocompleteServiceSpec.scala
@@ -39,7 +39,15 @@ class AutocompleteServiceSpec
     val params = Map("q" -> "Multiword Title").mapValues(Seq(_))
     val SearchResults(actualCompletions, _, _) = autocompleteService.doSearch(
       params, AuthParams(), None, None)._2
-    val expectedCompletions = List(CompletionResult("A Multiword Title", "A <span class=highlight>Multiword</span> <span class=highlight>Title</span>"))
+    val expectedCompletions = List(CompletionResult("A Multiword Title", "A <span class=highlight>Multiword</span> <span class=highlight>Title</span>", List("Multiword", "Title")))
+    actualCompletions should contain theSameElementsAs expectedCompletions
+  }
+
+  test("an autocomplete search with mulitple copies of the same term works as expected") {
+    val params = Map("q" -> "rammy").mapValues(Seq(_))
+    val SearchResults(actualCompletions, _, _) = autocompleteService.doSearch(
+      params, AuthParams(), None, None)._2
+    val expectedCompletions = List(CompletionResult("rammy is rammy", "<span class=highlight>rammy</span> is <span class=highlight>rammy</span>", List("rammy", "rammy")))
     actualCompletions should contain theSameElementsAs expectedCompletions
   }
 
@@ -49,7 +57,7 @@ class AutocompleteServiceSpec
       .mapValues(Seq(_))
     val SearchResults(actualCompletions, _, _) = autocompleteService.doSearch(
       params, AuthParams(), None, None)._2
-    val expectedCompletions = List(CompletionResult("One", "<span class=highlight>O</span>ne"))
+    val expectedCompletions = List(CompletionResult("One", "<span class=highlight>O</span>ne", List("O")))
     actualCompletions should contain theSameElementsAs expectedCompletions
   }
 }


### PR DESCRIPTION
#### What it do?

Uses a horrible regex to parse out the matched text from the highlighted displayTitle.  Because Elasticsearch doesn't have an option to get the matched text from a highlight query.  Yes, there might be a better solution, but this is blocking CLP and works.


#### How was it tested?
I added a test to the AutocompleteServiceSpec and ran several manual tests. 