### PR TITLE
EN-11786: don't use su to switch users

### DIFF
--- a/cetera-http/docker/ship.d/run
+++ b/cetera-http/docker/ship.d/run
@@ -10,12 +10,7 @@ export METRICS_DIR
 HEAP_SIZE=${CETERA_HEAP_SIZE:-512m}
 GC_LOG_DIR=${MESOS_SANDBOX:-/tmp}
 
-# we do not use the mesos switch_user feature, so the sandbox
-# has the wrong permissions, which prevents logs from being
-# written by the real (i.e. child) process.
-chmod 1777 ${GC_LOG_DIR}
-
-CMD="/usr/bin/java \
+/usr/bin/java \
   -Dconfig.file=${CETERA_CONFIG} \
   -Xms${HEAP_SIZE} \
   -Xmx${HEAP_SIZE} \
@@ -36,6 +31,4 @@ CMD="/usr/bin/java \
   -Djava.rmi.server.hostname=${ARK_HOST:-localhost} \
   -Dfile.encoding=UTF-8 \
   -jar ${CETERA_ROOT}/${CETERA_ARTIFACT}
-"
 
-exec su socrata -c "$CMD"


### PR DESCRIPTION
If we set the user in the marathon config, then theoretically everything
will work as that user!