### PR TITLE
EN-19036: Remove datalens view-moderation logic

### DIFF
--- a/cetera-http/src/main/scala/com/socrata/cetera/response/Format.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/response/Format.scala
@@ -80,12 +80,6 @@ object Format {
   private def approvalsContainId(doc: Document, id: Int): Boolean =
     doc.approvingDomainIds.exists(_.contains(id))
 
-  def datalensStatus(doc: Document): Option[String] =
-    if (doc.isDatalens) doc.moderationStatus else None
-
-  def datalensApproved(doc: Document): Option[Boolean] =
-    if (doc.isDatalens) Some(literallyApproved(doc)) else None
-
   def moderationStatus(doc: Document, viewsDomain: Domain): Option[String] = {
     viewsDomain.moderationEnabled match {
       case true => if (doc.isDefaultView) Some(ApprovalStatus.approved.status) else doc.moderationStatus
@@ -155,14 +149,12 @@ object Format {
     val contextDomainId = domainSet.searchContext.map(d => d.domainId).getOrElse(0)
     val routingApproval = routingApproved(doc, viewsDomain)
     val moderationApproval = moderationApproved(doc, viewsDomain)
-    val datalensApproval = datalensApproved(doc)
     val(moderationApprovalOnContext, routingApprovalOnContext) = contextApprovals(doc, viewsDomain, domainSet)
     val viewGrants = if (doc.grants.isEmpty) None else Some(doc.grants)
     val anonymousVis =
       doc.isPublic & doc.isPublished & !doc.isHiddenFromCatalog &
       routingApproval.getOrElse(true) & routingApprovalOnContext.getOrElse(true) &
-      moderationApproval.getOrElse(true) & moderationApprovalOnContext.getOrElse(true) &
-      datalensApproval.getOrElse(true)
+      moderationApproval.getOrElse(true) & moderationApprovalOnContext.getOrElse(true)
 
     Metadata(
       domain = viewsDomain.domainCname,
@@ -174,11 +166,9 @@ object Format {
       isModerationApprovedOnContext = moderationApprovalOnContext,
       isRoutingApproved = routingApproval,
       isRoutingApprovedOnContext = routingApprovalOnContext,
-      isDatalensApproved = datalensApproval,
       visibleToAnonymous = Some(anonymousVis),
       moderationStatus = moderationStatus(doc, viewsDomain),
       routingStatus = routingStatus(doc, viewsDomain),
-      datalensStatus = datalensStatus(doc),
       grants = viewGrants,
       approvals = doc.approvals.map(_.map(_.removeEmails)) // not bothering with auth to show emails
     )

--- a/cetera-http/src/main/scala/com/socrata/cetera/response/JsonResponses.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/response/JsonResponses.scala
@@ -64,7 +64,6 @@ case class Metadata(
     isModerationApprovedOnContext: Option[Boolean] = None,
     isRoutingApproved: Option[Boolean] = None,
     isRoutingApprovedOnContext: Option[Boolean] = None,
-    isDatalensApproved: Option[Boolean] = None,
     visibleToAnonymous: Option[Boolean] = None,
     moderationStatus: Option[String] = None,
     routingStatus: Option[String] = None,

--- a/cetera-http/src/main/scala/com/socrata/cetera/services/SearchService.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/services/SearchService.scala
@@ -44,7 +44,6 @@ class SearchService(
       extendedHost: Option[String],
       requestId: Option[String])
     : (StatusResponse, SearchResults[SearchResult], InternalTimings, Seq[String]) = {
-
     val now = Timings.now()
     val (authorizedUser, setCookies) = coreClient.optionallyAuthenticateUser(extendedHost, authParams, requestId)
     val ValidatedQueryParameters(searchParams, scoringParams, pagingParams, formatParams) =

--- a/cetera-http/src/main/scala/com/socrata/cetera/types/Document.scala
+++ b/cetera-http/src/main/scala/com/socrata/cetera/types/Document.scala
@@ -150,7 +150,6 @@ case class Document(
     license: Option[String]) {
 
   def isSharedOrOwned(userId: String): Boolean = owner.id == userId || sharedTo.contains(userId)
-  def isDatalens: Boolean = datatype.startsWith(DatalensDatatype.singular)
   def isStory: Boolean = datatype == StoryDatatype.singular
   def isHiddenFromCatalog: Boolean = hideFromCatalog.getOrElse(false)
 

--- a/cetera-http/src/test/resources/views/fxf-10.json
+++ b/cetera-http/src/test/resources/views/fxf-10.json
@@ -68,7 +68,7 @@
   "is_public": true,
   "is_published": true,
   "is_default_view": true,
-  "moderation_status": "",
+  "moderation_status": null,
   "approving_domain_ids": [
     2,
     3

--- a/cetera-http/src/test/resources/views/fxf-2.json
+++ b/cetera-http/src/test/resources/views/fxf-2.json
@@ -62,7 +62,7 @@
   "is_public": true,
   "is_published": true,
   "is_default_view": false,
-  "moderation_status": "pending",
+  "moderation_status": null,
   "approving_domain_ids": [],
   "rejecting_domain_ids": [
     3
@@ -86,8 +86,8 @@
   "attribution": null,
   "preview_image_id": null,
   "grants": [],
-  "hide_from_catalog": false,
-  "hide_from_data_json": false,
+  "hide_from_catalog": true,
+  "hide_from_data_json": true,
   "provenance": "community",
   "owner": {
     "id": "robin-hood"

--- a/cetera-http/src/test/resources/views/zeta-0011.json
+++ b/cetera-http/src/test/resources/views/zeta-0011.json
@@ -5,11 +5,11 @@
     "dataset_id": "zeta-0011",
     "parent_dataset_id": [],
     "domain_id": 0,
-    "nbe_id": "zeta-0011",
-    "obe_id": null
+    "nbe_id": null,
+    "obe_id": "zeta-0011"
   },
   "resource": {
-    "description": "rejected datalens",
+    "description": "hidden datalens",
     "parent_fxf": null,
     "updatedAt": "2016-09-19T10:37:21.143-07:00",
     "createdAt": "2016-09-19T10:37:21.143-07:00",
@@ -46,12 +46,10 @@
   "is_public": true,
   "is_published": true,
   "is_default_view": false,
-  "moderation_status": "rejected",
+  "moderation_status": null,
   "approving_domain_ids": [],
   "rejecting_domain_ids": [],
-  "pending_domain_ids": [
-    2
-  ],
+  "pending_domain_ids": [2],
   "is_approved_by_parent_domain": false,
   "is_rejected_by_parent_domain": false,
   "is_pending_on_parent_domain": false,
@@ -68,8 +66,8 @@
   "attribution": null,
   "preview_image_id": null,
   "grants": [],
-  "hide_from_catalog": false,
-  "hide_from_data_json": false,
+  "hide_from_catalog": true,
+  "hide_from_data_json": true,
   "provenance": "community",
   "owner": {
     "id": "lil-john"

--- a/cetera-http/src/test/resources/views/zeta-0015.json
+++ b/cetera-http/src/test/resources/views/zeta-0015.json
@@ -2,19 +2,20 @@
   "created_at": "2016-09-19T10:37:20.933-07:00",
   "updated_at": "2016-09-19T10:37:20.857-07:00",
   "socrata_id": {
-    "dataset_id": "zeta-0004",
+    "dataset_id": "zeta-0015",
     "parent_dataset_id": [],
-    "domain_id": 0,
-    "nbe_id": null,
-    "obe_id": "zeta-0004"
+    "domain_id": 3,
+    "nbe_id": "zeta-0015",
+    "obe_id": null
   },
   "resource": {
-    "description": "standalone visualization",
+    "description": "moderation rejected ra pending filtered view",
+    "nbe_fxf": "zeta-0004",
     "parent_fxf": null,
     "updatedAt": "2016-09-19T10:37:21.143-07:00",
     "createdAt": "2016-09-19T10:37:21.143-07:00",
-    "type": "datalens_chart",
-    "id": "zeta-0004",
+    "type": "filter",
+    "id": "zeta-0015",
     "name": "",
     "attribution": null,
     "provenance": "community",
@@ -27,7 +28,7 @@
     "categories": [],
     "tags": []
   },
-  "datatype": "datalens_chart",
+  "datatype": "filter",
   "viewtype": "",
   "indexed_metadata": {
     "name": "",
@@ -46,14 +47,12 @@
   "is_public": true,
   "is_published": true,
   "is_default_view": false,
-  "moderation_status": null,
+  "moderation_status": "rejected",
   "approving_domain_ids": [],
-  "rejecting_domain_ids": [],
-  "pending_domain_ids": [
-    2
-  ],
+  "rejecting_domain_ids": [3],
+  "pending_domain_ids": [2],
   "is_approved_by_parent_domain": false,
-  "is_rejected_by_parent_domain": false,
+  "is_rejected_by_parent_domain": true,
   "is_pending_on_parent_domain": false,
   "page_views": {
     "page_views_total": 42,
@@ -63,24 +62,15 @@
   "customer_category": "Standalone",
   "customer_tags": [],
   "shared_to": [
-    "cook-mons",
     "maid-marian"
   ],
   "attribution": null,
   "preview_image_id": null,
   "grants": [],
-  "hide_from_catalog": true,
-  "hide_from_data_json": true,
+  "hide_from_catalog": false,
+  "hide_from_data_json": false,
   "provenance": "community",
   "owner": {
     "id": "lil-john"
-  },
-  "approvals" : [ {
-    "outcome" : "publicize",
-    "state" : "pending",
-    "submitted_at" : "2017-10-31T12:00:00.000Z",
-    "submitter_id" : "robin-hood",
-    "submitter_name" : "Robin Hood",
-    "submitter_email" : "robin-hood@nottingham.com"
-  } ]
+  }
 }

--- a/cetera-http/src/test/resources/views/zeta-0016.json
+++ b/cetera-http/src/test/resources/views/zeta-0016.json
@@ -2,19 +2,20 @@
   "created_at": "2016-09-19T10:37:20.933-07:00",
   "updated_at": "2016-09-19T10:37:20.857-07:00",
   "socrata_id": {
-    "dataset_id": "zeta-0004",
+    "dataset_id": "zeta-0016",
     "parent_dataset_id": [],
-    "domain_id": 0,
-    "nbe_id": null,
-    "obe_id": "zeta-0004"
+    "domain_id": 3,
+    "nbe_id": "zeta-0016",
+    "obe_id": null
   },
   "resource": {
-    "description": "standalone visualization",
+    "description": "R&A rejected dataset",
+    "nbe_fxf": "zeta-0004",
     "parent_fxf": null,
     "updatedAt": "2016-09-19T10:37:21.143-07:00",
     "createdAt": "2016-09-19T10:37:21.143-07:00",
-    "type": "datalens_chart",
-    "id": "zeta-0004",
+    "type": "dataset",
+    "id": "zeta-0016",
     "name": "",
     "attribution": null,
     "provenance": "community",
@@ -27,7 +28,7 @@
     "categories": [],
     "tags": []
   },
-  "datatype": "datalens_chart",
+  "datatype": "dataset",
   "viewtype": "",
   "indexed_metadata": {
     "name": "",
@@ -48,12 +49,10 @@
   "is_default_view": false,
   "moderation_status": null,
   "approving_domain_ids": [],
-  "rejecting_domain_ids": [],
-  "pending_domain_ids": [
-    2
-  ],
+  "rejecting_domain_ids": [3],
+  "pending_domain_ids": [2],
   "is_approved_by_parent_domain": false,
-  "is_rejected_by_parent_domain": false,
+  "is_rejected_by_parent_domain": true,
   "is_pending_on_parent_domain": false,
   "page_views": {
     "page_views_total": 42,
@@ -63,24 +62,15 @@
   "customer_category": "Standalone",
   "customer_tags": [],
   "shared_to": [
-    "cook-mons",
     "maid-marian"
   ],
   "attribution": null,
   "preview_image_id": null,
   "grants": [],
-  "hide_from_catalog": true,
-  "hide_from_data_json": true,
+  "hide_from_catalog": false,
+  "hide_from_data_json": false,
   "provenance": "community",
   "owner": {
     "id": "lil-john"
-  },
-  "approvals" : [ {
-    "outcome" : "publicize",
-    "state" : "pending",
-    "submitted_at" : "2017-10-31T12:00:00.000Z",
-    "submitter_id" : "robin-hood",
-    "submitter_name" : "Robin Hood",
-    "submitter_email" : "robin-hood@nottingham.com"
-  } ]
+  }
 }

--- a/cetera-http/src/test/resources/views/zeta-0017.json
+++ b/cetera-http/src/test/resources/views/zeta-0017.json
@@ -1,20 +1,22 @@
+
 {
-  "created_at": "2016-09-19T10:37:20.933-07:00",
-  "updated_at": "2016-09-19T10:37:20.857-07:00",
+  "created_at": "2017-09-19T10:37:20.933-07:00",
+  "updated_at": "2017-09-19T10:37:20.857-07:00",
   "socrata_id": {
-    "dataset_id": "zeta-0004",
+    "dataset_id": "zeta-0017",
     "parent_dataset_id": [],
-    "domain_id": 0,
-    "nbe_id": null,
-    "obe_id": "zeta-0004"
+    "domain_id": 2,
+    "nbe_id": "zeta-0017",
+    "obe_id": null
   },
   "resource": {
-    "description": "standalone visualization",
+    "description": "R&A rejected dataset",
+    "nbe_fxf": "zeta-0004",
     "parent_fxf": null,
-    "updatedAt": "2016-09-19T10:37:21.143-07:00",
-    "createdAt": "2016-09-19T10:37:21.143-07:00",
-    "type": "datalens_chart",
-    "id": "zeta-0004",
+    "updatedAt": "2017-09-19T10:37:21.143-07:00",
+    "createdAt": "2017-09-19T10:37:21.143-07:00",
+    "type": "dataset",
+    "id": "zeta-0017",
     "name": "",
     "attribution": null,
     "provenance": "community",
@@ -27,7 +29,7 @@
     "categories": [],
     "tags": []
   },
-  "datatype": "datalens_chart",
+  "datatype": "dataset",
   "viewtype": "",
   "indexed_metadata": {
     "name": "",
@@ -48,12 +50,10 @@
   "is_default_view": false,
   "moderation_status": null,
   "approving_domain_ids": [],
-  "rejecting_domain_ids": [],
-  "pending_domain_ids": [
-    2
-  ],
+  "rejecting_domain_ids": [2],
+  "pending_domain_ids": [],
   "is_approved_by_parent_domain": false,
-  "is_rejected_by_parent_domain": false,
+  "is_rejected_by_parent_domain": true,
   "is_pending_on_parent_domain": false,
   "page_views": {
     "page_views_total": 42,
@@ -63,24 +63,15 @@
   "customer_category": "Standalone",
   "customer_tags": [],
   "shared_to": [
-    "cook-mons",
     "maid-marian"
   ],
   "attribution": null,
   "preview_image_id": null,
   "grants": [],
-  "hide_from_catalog": true,
-  "hide_from_data_json": true,
+  "hide_from_catalog": false,
+  "hide_from_data_json": false,
   "provenance": "community",
   "owner": {
     "id": "lil-john"
-  },
-  "approvals" : [ {
-    "outcome" : "publicize",
-    "state" : "pending",
-    "submitted_at" : "2017-10-31T12:00:00.000Z",
-    "submitter_id" : "robin-hood",
-    "submitter_name" : "Robin Hood",
-    "submitter_email" : "robin-hood@nottingham.com"
-  } ]
+  }
 }

--- a/cetera-http/src/test/resources/views/zeta-0018.json
+++ b/cetera-http/src/test/resources/views/zeta-0018.json
@@ -1,20 +1,22 @@
+
 {
-  "created_at": "2016-09-19T10:37:20.933-07:00",
-  "updated_at": "2016-09-19T10:37:20.857-07:00",
+  "created_at": "2018-09-19T10:37:20.933-07:00",
+  "updated_at": "2018-09-19T10:37:20.857-07:00",
   "socrata_id": {
-    "dataset_id": "zeta-0004",
+    "dataset_id": "zeta-0018",
     "parent_dataset_id": [],
-    "domain_id": 0,
-    "nbe_id": null,
-    "obe_id": "zeta-0004"
+    "domain_id": 2,
+    "nbe_id": "zeta-0018",
+    "obe_id": null
   },
   "resource": {
-    "description": "standalone visualization",
+    "description": "R&A pending dataset",
+    "nbe_fxf": "zeta-0004",
     "parent_fxf": null,
-    "updatedAt": "2016-09-19T10:37:21.143-07:00",
-    "createdAt": "2016-09-19T10:37:21.143-07:00",
-    "type": "datalens_chart",
-    "id": "zeta-0004",
+    "updatedAt": "2018-09-19T10:37:21.143-07:00",
+    "createdAt": "2018-09-19T10:37:21.143-07:00",
+    "type": "dataset",
+    "id": "zeta-0018",
     "name": "",
     "attribution": null,
     "provenance": "community",
@@ -27,7 +29,7 @@
     "categories": [],
     "tags": []
   },
-  "datatype": "datalens_chart",
+  "datatype": "dataset",
   "viewtype": "",
   "indexed_metadata": {
     "name": "",
@@ -49,12 +51,10 @@
   "moderation_status": null,
   "approving_domain_ids": [],
   "rejecting_domain_ids": [],
-  "pending_domain_ids": [
-    2
-  ],
+  "pending_domain_ids": [2],
   "is_approved_by_parent_domain": false,
   "is_rejected_by_parent_domain": false,
-  "is_pending_on_parent_domain": false,
+  "is_pending_on_parent_domain": true,
   "page_views": {
     "page_views_total": 42,
     "page_views_last_month": 42,
@@ -63,24 +63,15 @@
   "customer_category": "Standalone",
   "customer_tags": [],
   "shared_to": [
-    "cook-mons",
     "maid-marian"
   ],
   "attribution": null,
   "preview_image_id": null,
   "grants": [],
-  "hide_from_catalog": true,
-  "hide_from_data_json": true,
+  "hide_from_catalog": false,
+  "hide_from_data_json": false,
   "provenance": "community",
   "owner": {
     "id": "lil-john"
-  },
-  "approvals" : [ {
-    "outcome" : "publicize",
-    "state" : "pending",
-    "submitted_at" : "2017-10-31T12:00:00.000Z",
-    "submitter_id" : "robin-hood",
-    "submitter_name" : "Robin Hood",
-    "submitter_email" : "robin-hood@nottingham.com"
-  } ]
+  }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/TestESData.scala
@@ -57,7 +57,7 @@ trait TestESData extends TestESDomains with TestESUsers {
     // we used to construct them in commit 1442a6b08.
     val series1DocFiles = (0 to 13).map(i => s"/views/fxf-$i.json")
     val series2DocFiles = (1 to 9).map(i => s"/views/zeta-000$i.json") ++
-      (10 to 14).map(i => s"/views/zeta-00$i.json") ++
+      (10 to 18).map(i => s"/views/zeta-00$i.json") ++
       (1 to 5).map(i => s"/views/domain-9-view-$i.json")
 
     val series1Docs = series1DocFiles.map { f =>
@@ -173,7 +173,7 @@ trait TestESData extends TestESDomains with TestESUsers {
   def fxfs(searchResults: SearchResults[SearchResult]): Seq[String] =
     searchResults.results.map(fxfs)
 
-  def fxfs(docs: Seq[Document]): Seq[String] = docs.map(_.socrataId.datasetId)
+  def fxfs(docs: Seq[Document]): Seq[String] = docs.map(_.socrataId.datasetId).toSet.toSeq
 
   def emptyAndRemoveDir(dir: File): Unit = {
     if (dir.isDirectory) {
@@ -185,7 +185,6 @@ trait TestESData extends TestESDomains with TestESUsers {
   def isApproved(res: SearchResult): Boolean = {
     val raApproved = res.metadata.isRoutingApproved.map(identity(_)).getOrElse(true) // None implies not relevant (so approved by default)
     val vmApproved = res.metadata.isModerationApproved.map(identity(_)).getOrElse(true)
-    val dlApproved = res.metadata.isDatalensApproved.map(identity(_)).getOrElse(true)
-    raApproved && vmApproved && dlApproved
+    raApproved && vmApproved
   }
 }

--- a/cetera-http/src/test/scala/com/socrata/cetera/response/FormatSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/response/FormatSpec.scala
@@ -229,51 +229,6 @@ class FormatSpec extends WordSpec with ShouldMatchers with TestESData {
     }
   }
 
-
-  "the datalensStatus method" should {
-    val datalens = docs(2)
-
-    "return None if the view isn't a datalens" in {
-      Format.datalensStatus(docs(0)) should be(None)
-    }
-
-    "return rejected if the datalens is rejected" in {
-      Format.datalensStatus(datalens.copy(moderationStatus = Some("rejected"))) should be(Some("rejected"))
-    }
-
-    "return pending if the datalens is pending" in {
-      Format.datalensStatus(datalens.copy(moderationStatus = Some("pending"))) should be(Some("pending"))
-    }
-
-    "return approved if the datalens is approved (for all datalens types)" in {
-      Format.datalensStatus(datalens.copy(moderationStatus = Some("approved"))) should be(Some("approved"))
-      Format.datalensStatus(datalens.copy(moderationStatus = Some("approved"), datatype = "datalens_chart")) should be(Some("approved"))
-      Format.datalensStatus(datalens.copy(moderationStatus = Some("approved"), datatype = "datalens_map")) should be(Some("approved"))
-    }
-  }
-
-  "the datalensApproved method" should {
-    val datalens = docs(2)
-
-    "return None if the view isn't a datalens" in {
-      Format.datalensApproved(docs(0)) should be(None)
-    }
-
-    "return false if the datalens is rejected" in {
-      Format.datalensApproved(datalens.copy(moderationStatus = Some("rejected"))) should be(Some(false))
-    }
-
-    "return false if the datalens is pending" in {
-      Format.datalensApproved(datalens.copy(moderationStatus = Some("pending"))) should be(Some(false))
-    }
-
-    "return true if the datalens is approved (for all datalens types)" in {
-      Format.datalensApproved(datalens.copy(moderationStatus = Some("approved"))) should be(Some(true))
-      Format.datalensApproved(datalens.copy(moderationStatus = Some("approved"), datatype = "datalens_chart")) should be(Some(true))
-      Format.datalensApproved(datalens.copy(moderationStatus = Some("approved"), datatype = "datalens_map")) should be(Some(true))
-    }
-  }
-
   "the moderationStatus method" should {
     "return None if the domain does not have moderation enabled" in {
       val unmoderatedDomain = domains(0)

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpec.scala
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream
 import java.nio.charset.{Charset, CodingErrorAction}
 import java.util.Collections
 import javax.servlet.http.HttpServletRequest
+import org.apache.commons.io.FileUtils
 import scala.collection.JavaConverters._
 
 import com.rojoma.json.v3.interpolation._
@@ -36,7 +37,11 @@ class SearchServiceSpec extends FunSuiteLike
   with BeforeAndAfterAll
   with BeforeAndAfterEach {
 
-  override protected def beforeAll(): Unit = bootstrapData()
+  override protected def beforeAll(): Unit = {
+    // Remove the contents of /tmp/metrics
+    FileUtils.cleanDirectory(balboaDir)
+    bootstrapData()
+  }
 
   override def beforeEach(): Unit = mockServer.reset()
 
@@ -205,7 +210,9 @@ class SearchServiceSpec extends FunSuiteLike
       "zeta-0002" -> true,
       "zeta-0009" -> false,
       "zeta-0013" -> false,
-      "zeta-0014" -> false
+      "zeta-0014" -> false,
+      "zeta-0015" -> false,
+      "zeta-0016" -> false
     )
 
     prepareAuthenticatedUser(cookie, host, authedUserBody)

--- a/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpecForAnonymousUsers.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/services/SearchServiceSpecForAnonymousUsers.scala
@@ -147,7 +147,7 @@ class SearchServiceSpecForAnonymousUsers
     )
     val res = service.doSearch(params.mapValues(Seq(_)), AuthParams(), None, None)._2.results
     res.length should be(1)
-    val expectedMetadata = Metadata("robert.demo.socrata.com",None,Some(true),Some(true),Some(false),None,None,None,None,None,Some(true),None,None,None,None,None,None)
+    val expectedMetadata = Metadata("robert.demo.socrata.com", None, Some(true), Some(true), Some(false), None, None, None, None, Some(true), None, None, None, None, None, None)
     res(0).metadata should be(expectedMetadata)
   }
 
@@ -159,10 +159,10 @@ class SearchServiceSpecForAnonymousUsers
     )
     val res = service.doSearch(params.mapValues(Seq(_)), AuthParams(), None, None)._2.results
     res.length should be(1)
-    val expectedMetadata = Metadata("petercetera.net",None,Some(true),Some(true),Some(false),None,None,None,None,None,
-      Some(true),None,None,None,None,None,
-      Some(Vector(FlattenedApproval("publicize","rejected","2017-10-31T12:00:00.000Z","robin-hood","Robin Hood", None,
-        Some(false),Some("2017-11-01T12:00:00.000Z"),Some("honorable.sheriff"),Some("The Honorable Sheriff of Nottingham"), None))))
+    val expectedMetadata = Metadata("petercetera.net", None, Some(true), Some(true), Some(false), None, None, None, None,
+      Some(true), None, None, None, None, None,
+      Some(Vector(FlattenedApproval("publicize", "rejected", "2017-10-31T12:00:00.000Z", "robin-hood", "Robin Hood", None,
+        Some(false), Some("2017-11-01T12:00:00.000Z"), Some("honorable.sheriff"), Some("The Honorable Sheriff of Nottingham"), None))))
     res(0).metadata should be(expectedMetadata)
   }
 

--- a/cetera-http/src/test/scala/com/socrata/cetera/types/DocumentSpec.scala
+++ b/cetera-http/src/test/scala/com/socrata/cetera/types/DocumentSpec.scala
@@ -63,7 +63,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-0").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -77,7 +76,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-4").get
       doc.isPublic should be(false)
       doc.isPublished should be(false)
-      doc.isDatalens should be(false)
       doc.isStory should be(true)
       doc.isHiddenFromCatalog should be(true)
       doc.isDefaultView should be(false)
@@ -91,7 +89,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-8").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
@@ -105,7 +102,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0001").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -119,14 +115,12 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0004").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(true)
       doc.isStory should be(false)
-      doc.isHiddenFromCatalog should be(false)
+      doc.isHiddenFromCatalog should be(true)
       doc.isDefaultView should be(false)
       doc.isSharedOrOwned("lil-john") should be(true)
       doc.isSharedOrOwned("cook-mons") should be(true)
       doc.isSharedOrOwned("maid-marian") should be(true)
-      verifyVmPending(doc)  // b/c is a datalens
       verifyRaMissing(doc, 0)
       verifyRaPending(doc, 2)
     }
@@ -135,7 +129,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0006").get
       doc.isPublic should be(true)
       doc.isPublished should be(false)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(true)
       doc.isDefaultView should be(true)
@@ -150,7 +143,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0007").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
@@ -165,13 +157,11 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0011").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(true)
       doc.isStory should be(false)
-      doc.isHiddenFromCatalog should be(false)
+      doc.isHiddenFromCatalog should be(true)
       doc.isDefaultView should be(false)
       doc.isSharedOrOwned("lil-john") should be(true)
       doc.isSharedOrOwned("maid-marian") should be(true)
-      verifyVmRejected(doc)  // b/c is a datalens
       verifyRaMissing(doc, 0)
       verifyRaPending(doc, 2)
     }
@@ -180,12 +170,10 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0012").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(true)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
       doc.isSharedOrOwned("lil-john") should be(true)
-      verifyVmApproved(doc)  // b/c is a datalens
       verifyRaMissing(doc, 0)
       verifyRaApproved(doc, 2)
     }
@@ -196,7 +184,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-1").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -209,7 +196,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-5").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -223,7 +209,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-9").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -240,12 +225,10 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-2").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(true)
       doc.isStory should be(false)
-      doc.isHiddenFromCatalog should be(false)
+      doc.isHiddenFromCatalog should be(true)
       doc.isDefaultView should be(false)
       doc.isSharedOrOwned("robin-hood") should be(true)
-      verifyVmPending(doc)  // b/c is a datalens
       verifyRaPending(doc, 2)
       verifyRaMissing(doc, 0)
       verifyRaRejected(doc, 3)
@@ -255,7 +238,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-6").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -270,7 +252,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-10").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(true)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
@@ -285,7 +266,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0003").get
       doc.isPublic should be(false)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
@@ -301,7 +281,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0005").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -316,7 +295,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0010").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(true)
       doc.isDefaultView should be(false)
@@ -326,6 +304,32 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       verifyRaMissing(doc, 0)
       verifyRaRejected(doc, 3)
     }
+
+    "have the expected statuses for zeta-0017" in {
+      val doc = docs.find(d => d.socrataId.datasetId == "zeta-0017").get
+      doc.isPublic should be(true)
+      doc.isPublished should be(true)
+      doc.isStory should be(false)
+      doc.isHiddenFromCatalog should be(false)
+      doc.isDefaultView should be(false)
+      doc.isSharedOrOwned("maid-marian") should be(true)
+      doc.isSharedOrOwned("lil-john") should be(true)
+      verifyVmMissing(doc)
+      verifyRaRejected(doc, 2)
+    }
+
+    "have the expected statuses for zeta-0018" in {
+      val doc = docs.find(d => d.socrataId.datasetId == "zeta-0018").get
+      doc.isPublic should be(true)
+      doc.isPublished should be(true)
+      doc.isStory should be(false)
+      doc.isHiddenFromCatalog should be(false)
+      doc.isDefaultView should be(false)
+      doc.isSharedOrOwned("maid-marian") should be(true)
+      doc.isSharedOrOwned("lil-john") should be(true)
+      verifyVmMissing(doc)
+      verifyRaPending(doc, 2)
+    }
   }
 
   "domain 3 is a customer domain with both VM & RA that does not federate anywhere" should {
@@ -333,7 +337,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-3").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
       doc.isSharedOrOwned("prince-john") should be(true)
@@ -345,7 +348,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-7").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -358,7 +360,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-11").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isPublic should be(true)
@@ -371,7 +372,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "fxf-12").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
@@ -384,7 +384,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0002").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -397,7 +396,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0009").get
       doc.isPublic should be(false)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isPublic should be(false)
@@ -410,7 +408,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0013").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -424,7 +421,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0014").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(true)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -433,6 +429,34 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       verifyVmApproved(doc)
       verifyRaRejected(doc, 3)
     }
+
+    "have the expected statuses for zeta-0015" in {
+      val doc = docs.find(d => d.socrataId.datasetId == "zeta-0015").get
+      doc.isPublic should be(true)
+      doc.isPublished should be(true)
+      doc.isStory should be(false)
+      doc.isHiddenFromCatalog should be(false)
+      doc.isDefaultView should be(false)
+      doc.isSharedOrOwned("maid-marian") should be(true)
+      doc.isSharedOrOwned("lil-john") should be(true)
+      verifyVmRejected(doc)
+      verifyRaRejected(doc, 3)
+      verifyRaPending(doc, 2)
+    }
+
+    "have the expected statuses for zeta-0016" in {
+      val doc = docs.find(d => d.socrataId.datasetId == "zeta-0016").get
+      doc.isPublic should be(true)
+      doc.isPublished should be(true)
+      doc.isStory should be(false)
+      doc.isHiddenFromCatalog should be(false)
+      doc.isDefaultView should be(false)
+      doc.isSharedOrOwned("maid-marian") should be(true)
+      doc.isSharedOrOwned("lil-john") should be(true)
+      verifyVmMissing(doc)
+      verifyRaRejected(doc, 3)
+      verifyRaPending(doc, 2)
+    }
   }
 
   "domain 8 is locked-down customer domain with both VM & RA that does not federate anywhere" should {
@@ -440,7 +464,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "zeta-0008").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(true)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(false)
@@ -455,7 +478,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "1234-5678").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
@@ -466,7 +488,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "1234-5679").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
@@ -477,7 +498,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "1234-5680").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
@@ -489,7 +509,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       doc.isPublic should be(true)
       doc.isPublished should be(true)
       doc.isStory should be(false)
-      doc.isDatalens should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
       doc.isSharedOrOwned("honorable.sheriff") should be(true)
@@ -499,7 +518,6 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
       val doc = docs.find(d => d.socrataId.datasetId == "1234-5682").get
       doc.isPublic should be(true)
       doc.isPublished should be(true)
-      doc.isDatalens should be(false)
       doc.isStory should be(false)
       doc.isHiddenFromCatalog should be(false)
       doc.isDefaultView should be(true)
@@ -507,4 +525,3 @@ class DocumentSpec extends WordSpec with ShouldMatchers with TestESData with Bef
     }
   }
 }
-


### PR DESCRIPTION
## What it do?

- removes all of the usages of `datalensStatus` and `datalensApproved`. The frontend now sets `hideFromCatalog` and `hideFromdataJson` when the "hidden from catalog" value is changed either from the datalens itself or from the SIAM
- adds a few new test files to make sure that we have examples for almost-all the cases of visibility on each domain.